### PR TITLE
use system certificate store for attic client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -24,7 +24,7 @@ humantime = "2.1.0"
 indicatif = "0.17.2"
 lazy_static = "1.4.0"
 regex = "1.7.0"
-reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls", "rustls-tls-native-roots", "stream"] }
 serde = { version = "1.0.151", features = ["derive"] }
 serde_json = "1.0.91"
 toml = "0.5.10"


### PR DESCRIPTION
I just ran into an issue using attic with a self hosted CA: the attic client does not use the certificate store of the system. I don't know if this is an intentional design decision. If it isn't this PR should fix the issue.