### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ And yes, it works on macOS too!
 Attic is available under the **Apache License, Version 2.0**.
 See `LICENSE` for details.
 
-By contributing to the project, you agree to license your work under the aforementioned licenses.
+By contributing to the project, you agree to license your work under the aforementioned license.


### PR DESCRIPTION
According to the README and the LICENSE files the project is licensed under only one license.