### PR TITLE
nixos: Make the group and user name under which attic runs configurable

### DIFF
--- a/nixos/atticd.nix
+++ b/nixos/atticd.nix
@@ -83,6 +83,20 @@ in
         type = types.nullOr types.path;
         default = null;
       };
+      user = lib.mkOption {
+        description = ''
+          The group under which attic runs.
+        '';
+        type = types.str;
+        default = "atticd";
+      };
+      group = lib.mkOption {
+        description = ''
+          The user under which attic runs.
+        '';
+        type = types.str;
+        default = "atticd";
+      };
       settings = lib.mkOption {
         description = ''
           Structured configurations of atticd.
@@ -156,6 +170,8 @@ in
           EnvironmentFile = cfg.credentialsFile;
           StateDirectory = "atticd"; # for usage with local storage and sqlite
           DynamicUser = true;
+          User = cfg.user;
+          Group = cfg.group;
           ProtectHome = true;
           ProtectHostname = true;
           ProtectKernelLogs = true;


### PR DESCRIPTION
This is useful for postgreSQL's peer authentication method (which checks if the authenticating user's name agrees with the role name).

This change should be backward compatible.