### PR TITLE
nixos: Suppress systemd-run's output in atticadm wrapper

### DIFF
--- a/nixos/atticd.nix
+++ b/nixos/atticd.nix
@@ -35,6 +35,7 @@ let
 
   atticadmWrapper = pkgs.writeShellScriptBin "atticd-atticadm" ''
     exec systemd-run \
+      --quiet \
       --pty \
       --same-dir \
       --wait \


### PR DESCRIPTION
Currently, the output of the atticadm wrapper is cluttered by the output of systemd-run. This pull request adds a `--quiet` flag to suppress them.