### PR TITLE
Increase narinfo size limit to 1MiB

### DIFF
--- a/server/src/api/v1/upload_path.rs
+++ b/server/src/api/v1/upload_path.rs
@@ -55,7 +55,9 @@ use crate::database::{AtticDatabase, ChunkGuard, NarGuard};
 const CONCURRENT_CHUNK_UPLOADS: usize = 10;
 
 /// The maximum size of the upload info JSON.
-const MAX_NAR_INFO_SIZE: usize = 64 * 1024; // 64 KiB
+///
+/// TODO: Make this configurable
+const MAX_NAR_INFO_SIZE: usize = 1 * 1024 * 1024; // 1 MiB
 
 type CompressorFn<C> = Box<dyn FnOnce(C) -> Box<dyn AsyncRead + Unpin + Send> + Send>;
 


### PR DESCRIPTION
I was still encountering failures due to narinfo files being too large,
even with the increased 64kiB limit. This commit increases it to 1MiB
which is hopefully larger than any “reasonable” derivation, while also
not being too large for the server to keep in memory at once.
