### PR TITLE
nixos: add storage path to ReadWritePaths

### DIFF
--- a/nixos/atticd.nix
+++ b/nixos/atticd.nix
@@ -203,6 +203,10 @@ in
           RestrictNamespaces = true;
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
+          ReadWritePaths = let
+            path = cfg.settings.storage.path;
+            isDefaultStateDirectory = path == "/var/lib/atticd" || lib.hasPrefix "/var/lib/atticd/" path;
+          in lib.optionals (cfg.settings.storage.type or "" == "local" && !isDefaultStateDirectory) [ path ];
         };
       };
 


### PR DESCRIPTION
Prevents "read only storage" errors when setting a non-default storage path.