### PR TITLE
client: truncate config file before overwriting

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -93,6 +93,7 @@ impl Config {
             let mut file = OpenOptions::new()
                 .create(true)
                 .write(true)
+                .truncate(true)
                 .mode(FILE_MODE)
                 .open(path)?;
 


### PR DESCRIPTION
Otherwise overwriting the configuration with a shorter token will lead to a corrupted config file.