### PR TITLE
client: allow storing the client token in a separate file

### DIFF
--- a/client/src/api/mod.rs
+++ b/client/src/api/mod.rs
@@ -62,7 +62,7 @@ pub struct StructuredApiError {
 
 impl ApiClient {
     pub fn from_server_config(config: ServerConfig) -> Result<Self> {
-        let client = build_http_client(config.token.as_deref());
+        let client = build_http_client(config.token()?.as_deref());
 
         Ok(Self {
             endpoint: Url::parse(&config.endpoint)?,

--- a/client/src/command/login.rs
+++ b/client/src/command/login.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 
 use crate::cache::ServerName;
 use crate::cli::Opts;
-use crate::config::{Config, ServerConfig};
+use crate::config::{Config, ServerConfig, ServerTokenConfig};
 
 /// Log into an Attic server.
 #[derive(Debug, Parser)]
@@ -32,8 +32,10 @@ pub async fn run(opts: Opts) -> Result<()> {
 
         server.endpoint = sub.endpoint.to_owned();
 
-        if sub.token.is_some() {
-            server.token = sub.token.to_owned();
+        if let Some(token) = &sub.token {
+            server.token = Some(ServerTokenConfig::Raw {
+                token: token.clone(),
+            });
         }
     } else {
         eprintln!("✍️ Configuring server \"{}\"", sub.name.as_str());
@@ -42,7 +44,10 @@ pub async fn run(opts: Opts) -> Result<()> {
             sub.name.to_owned(),
             ServerConfig {
                 endpoint: sub.endpoint.to_owned(),
-                token: sub.token.to_owned(),
+                token: sub
+                    .token
+                    .to_owned()
+                    .map(|token| ServerTokenConfig::Raw { token }),
             },
         );
     }

--- a/client/src/command/use.rs
+++ b/client/src/command/use.rs
@@ -49,7 +49,7 @@ pub async fn run(opts: Opts) -> Result<()> {
     nix_config.add_trusted_public_key(&public_key);
 
     // Modify netrc
-    if let Some(token) = &server.token {
+    if let Some(token) = server.token()? {
         eprintln!("+ Access Token");
 
         let mut nix_netrc = NixNetrc::load().await?;


### PR DESCRIPTION
This allows to configure the client through nixos/home-manager while keeping the secrets separate.