### PR TITLE
crane.nix: Suppress warning of missing version attribute in Cargo.toml

### DIFF
--- a/crane.nix
+++ b/crane.nix
@@ -46,7 +46,7 @@ let
 
   cargoArtifacts = craneLib.buildDepsOnly {
     pname = "attic";
-    inherit src nativeBuildInputs buildInputs;
+    inherit src version nativeBuildInputs buildInputs;
 
     # By default it's "use-symlink", which causes Crane's `inheritCargoArtifactsHook`
     # to copy the artifacts using `cp --no-preserve=mode` which breaks the executable


### PR DESCRIPTION
Suppress this annoying warning (https://github.com/ipetkov/crane/issues/281):

```console
$ nix build github:zhaofengli/attic
trace: warning: crane cannot find version attribute in /nix/store/qdggd1m9zk6kq29fc3kvf6prb8xabdfr-source/Cargo.toml, consider setting `version = "...";` explicitly
```