### PR TITLE
fix: writing config does not truncate

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -93,6 +93,7 @@ impl Config {
             let mut file = OpenOptions::new()
                 .create(true)
                 .write(true)
+                .truncate(true)
                 .mode(FILE_MODE)
                 .open(path)?;
 


### PR DESCRIPTION
I encountered this during trying the demo, when I changed my url to something shorter:
```
❯ attic login local http://localhost:8080 ey..ok
✍ Configuring server "local"

❯ attic login local http://khonsu:8080 ey..ok
✍ Overwriting server "local"

❯ bat ~/.config/attic/config.toml
   1   │ default-server = "local"
   2   │
   3   │ [servers.local]
   4   │ endpoint = "http://khonsu:8080"
   5   │ token = "ey..ok"
   6   │ k
```

and attic failed trying to parse the toml :yum: 