### PR TITLE
Open the default store, not `auto`

### DIFF
--- a/attic/src/nix_store/bindings/nix.cpp
+++ b/attic/src/nix_store/bindings/nix.cpp
@@ -92,7 +92,7 @@ CNixStore::CNixStore() {
 		g_init_nix_done = true;
 	}
 
-	this->store = nix::openStore("auto", params);
+	this->store = nix::openStore(nix::settings.storeUri.get(), params);
 }
 
 RString CNixStore::store_dir() {


### PR DESCRIPTION
This allows connecting to other stores by setting `NIX_REMOTE`, or the `store` setting in `nix.conf`. This can be helpful for migrating from a flat-file binary cache, using chroot stores, or otherwise pushing from more varied stores:

NIX_REMOTE=file:///var/lib/nix-binary-cache attic push magic $paths