### PR TITLE
Filter derivation by regex

### DIFF
--- a/attic/src/nix_store/nix_store.rs
+++ b/attic/src/nix_store/nix_store.rs
@@ -5,12 +5,13 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use regex::Regex;
 use tokio::task::spawn_blocking;
 
 use super::bindings::{open_nix_store, AsyncWriteAdapter, FfiNixStore};
 use super::{to_base_name, StorePath, ValidPathInfo};
-use crate::hash::Hash;
 use crate::error::AtticResult;
+use crate::hash::Hash;
 
 /// High-level wrapper for the Unix Domain Socket Nix Store.
 pub struct NixStore {
@@ -156,6 +157,7 @@ impl NixStore {
         flip_directions: bool,
         include_outputs: bool,
         include_derivers: bool,
+        filter: Option<Regex>,
     ) -> AtticResult<Vec<StorePath>> {
         let inner = self.inner.clone();
 
@@ -174,16 +176,20 @@ impl NixStore {
 
             Ok(cxx_vector
                 .iter()
-                .map(|s| {
+                .filter_map(|s| {
                     let osstr = OsStr::from_bytes(s.as_bytes());
                     let pb = PathBuf::from(osstr);
 
                     // Safety: The C++ implementation already checks the StorePath
                     // for correct format (which also implies valid UTF-8)
                     #[allow(unsafe_code)]
-                    unsafe {
-                        StorePath::from_base_name_unchecked(pb)
+                    let store_path = unsafe { StorePath::from_base_name_unchecked(pb) };
+                    if let Some(ref filter) = filter {
+                        if filter.is_match(&store_path.name()) {
+                            return None;
+                        }
                     }
+                    Some(store_path)
                 })
                 .collect())
         })
@@ -201,7 +207,8 @@ impl NixStore {
 
             // FIXME: Make this more ergonomic and efficient
             let nar_size = c_path_info.pin_mut().nar_size();
-            let nar_sha256_hash: [u8; 32] = c_path_info.pin_mut().nar_sha256_hash().try_into().unwrap();
+            let nar_sha256_hash: [u8; 32] =
+                c_path_info.pin_mut().nar_sha256_hash().try_into().unwrap();
             let references = c_path_info
                 .pin_mut()
                 .references()

--- a/attic/src/nix_store/tests/mod.rs
+++ b/attic/src/nix_store/tests/mod.rs
@@ -212,7 +212,7 @@ fn test_compute_fs_closure_multi() {
         ];
 
         let actual: HashSet<StorePath> = store
-            .compute_fs_closure_multi(paths, false, false, false)
+            .compute_fs_closure_multi(paths, false, false, false, None)
             .await
             .expect("Could not compute closure")
             .into_iter()

--- a/client/src/command/push.rs
+++ b/client/src/command/push.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use indicatif::MultiProgress;
+use regex::Regex;
 
 use crate::api::ApiClient;
 use crate::cache::CacheRef;
@@ -23,6 +24,10 @@ pub struct Push {
 
     /// The store paths to push.
     paths: Vec<PathBuf>,
+
+    /// Derivation names to be filted out.
+    #[clap(long)]
+    filter: Option<Regex>,
 
     /// Push the specified paths only and do not compute closures.
     #[clap(long)]
@@ -78,7 +83,12 @@ pub async fn run(opts: Opts) -> Result<()> {
 
     let pusher = Pusher::new(store, api, cache.to_owned(), cache_config, mp, push_config);
     let plan = pusher
-        .plan(roots, sub.no_closure, sub.ignore_upstream_cache_filter)
+        .plan(
+            roots,
+            sub.no_closure,
+            sub.ignore_upstream_cache_filter,
+            sub.filter.clone(),
+        )
         .await?;
 
     if plan.store_path_map.is_empty() {


### PR DESCRIPTION
Addresses #72 

Adds an extra optional flag to `attic push`:  `--filter `  which can be used like so:

```bash
attic push /run/current-system/ --filter '^((steam|appimage)-run|(nvidia|rust).*)$'
```

Which would push the whole system closure execpt store paths matching the regex such as `stream-run`, `appimage-run` or rust releated derivations.

I guess it would make sense, to integrate this functionally into other commands such as `watch-store` as well, I'll be happy to patch those commands as well if this feature is of interest.