### PR TITLE
Use --pipe for systemd-run

### DIFF
--- a/integration-tests/basic/default.nix
+++ b/integration-tests/basic/default.nix
@@ -186,8 +186,8 @@ in {
       server.wait_for_unit('atticd.service')
       client.wait_until_succeeds("curl -sL http://server:8080", timeout=40)
 
-      root_token = server.succeed("${cmd.atticadm} make-token --sub 'e2e-root' --validity '1 month' --push '*' --pull '*' --delete '*' --create-cache '*' --destroy-cache '*' --configure-cache '*' --configure-cache-retention '*'").strip()
-      readonly_token = server.succeed("${cmd.atticadm} make-token --sub 'e2e-root' --validity '1 month' --pull 'test'").strip()
+      root_token = server.succeed("${cmd.atticadm} make-token --sub 'e2e-root' --validity '1 month' --push '*' --pull '*' --delete '*' --create-cache '*' --destroy-cache '*' --configure-cache '*' --configure-cache-retention '*' </dev/null").strip()
+      readonly_token = server.succeed("${cmd.atticadm} make-token --sub 'e2e-root' --validity '1 month' --pull 'test' </dev/null").strip()
 
       client.succeed(f"attic login --set-default root http://server:8080 {root_token}")
       client.succeed(f"attic login readonly http://server:8080 {readonly_token}")

--- a/nixos/atticd.nix
+++ b/nixos/atticd.nix
@@ -36,6 +36,7 @@ let
   atticadmWrapper = pkgs.writeShellScriptBin "atticd-atticadm" ''
     exec systemd-run \
       --quiet \
+      --pipe \
       --pty \
       --same-dir \
       --wait \


### PR DESCRIPTION
Without --pipe stderr and stdout are combined, breaking scripts that use atticd-atticadm when it generates warnings.

Before:

~~~console
# atticd-atticadm make-token --validity 4h --sub albert 2>/dev/null
/nix/store/rnvn0g8qfnwspgy5fl14f5r438labrh8-atticadm: line 3: cd: /root: Permission denied
Warning: Failed to change directory to /root
HolTYkSVSqLp+7SMzwfkOoj6X5Baa5oVKsrSUSv04wGMcSM1f2hFnLP6mPYguZwYWDaRCCZ0Sl/7X/iO9wvNVuKCgi37ib2z06Jbj59j1MeKQ2CUFWpYjGzXQMq96Qh84W8JTg==
~~~

After:

~~~console
# atticd-atticadm make-token --validity 4h --sub albert 2>/dev/null
HolTYkSVSqLp+7SMzwfkOoj6X5Baa5oVKsrSUSv04wGMcSM1f2hFnLP6mPYguZwYWDaRCCZ0Sl/7X/iO9wvNVuKCgi37ib2z06Jbj59j1MeKQ2CUFWpYjGzXQMq96Qh84W8JTg==
~~~
