### PR TITLE
nixos: use configured user in admin wrapper

### DIFF
--- a/nixos/atticd.nix
+++ b/nixos/atticd.nix
@@ -43,7 +43,7 @@ let
       --service-type=exec \
       --property=EnvironmentFile=${cfg.credentialsFile} \
       --property=DynamicUser=yes \
-      --property=User=atticd \
+      --property=User=${cfg.user} \
       --property=Environment=ATTICADM_PWD=$(pwd) \
       --working-directory / \
       -- \


### PR DESCRIPTION
follow-up to 1a3b6513b02202198bb497608d0cedc45119799b