### PR TITLE
Remove un-used import

### DIFF
--- a/client/src/cache.rs
+++ b/client/src/cache.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
-pub use attic::cache::{CacheName, CacheNamePattern};
+pub use attic::cache::{CacheName};
 
 /// A reference to a cache.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
When using attic from the overlay it seems to be using rust 1.75 (im on nixos-unstable) which errors the build because of this un-used import. 


Might be worth to pin the rust version in the nix build instead of using whats in nix pkgs for the overlay at least.

Verified the fix by updating my flake input to this branch and it built without issue