### PR TITLE
nixos: restart atticd on failure

### DIFF
--- a/nixos/atticd.nix
+++ b/nixos/atticd.nix
@@ -199,6 +199,8 @@ in
           ProtectKernelTunables = true;
           ProtectProc = "invisible";
           ProtectSystem = "strict";
+          Restart = "on-failure";
+          RestartSec = 10;
           RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
           RestrictNamespaces = true;
           RestrictRealtime = true;


### PR DESCRIPTION
Which we discovered did not happen automatically during a database switch.