### PR TITLE
gc.rs: `LIMIT` number of `orphan_chunks`, fixes #115

### DIFF
--- a/server/src/gc.rs
+++ b/server/src/gc.rs
@@ -159,8 +159,8 @@ async fn run_reap_orphan_chunks(state: &State) -> Result<()> {
     let storage = state.storage().await?;
 
     let orphan_chunk_limit = match db.get_database_backend() {
-        // Default value of --max-allowed-packet https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet
-        sea_orm::DatabaseBackend::MySql    => 67108864,
+        // Arbitrarily chosen sensible value since there's no good default to choose from for MySQL 
+        sea_orm::DatabaseBackend::MySql    => 1000,
         // Panic limit set by sqlx for postgresql: https://github.com/launchbadge/sqlx/issues/671#issuecomment-687043510
         sea_orm::DatabaseBackend::Postgres => u64::from(u16::MAX),
         // Default statement limit imposed by sqlite: https://www.sqlite.org/limits.html#max_variable_number 


### PR DESCRIPTION
This change fixes the immediate issue documented by #115.

There are some notable caveats though: for both mysql and sqlite, the parameter limits are configurable in the database, so my choice to use the defaults isn't adequate (but it is at least better than having no limit at all).

I think the more sensible and general approach that would solve both of these problems would be to:

- Limit `orphan_chunks` to something static and small, e.g 300 results.
- Use chained `OR`s instead of `IN` to get the most performant query possible.

... I didn't implement that though because we need something that brings attic back into service ASAP and I think that change is much more invasive than the one I'm proposing here and wanted to feel out @zhaofengli's receptiveness to that kind of change.

[EDIT] another more general approach would be to write a SELECT query for the orphan chunks that is used to get the chunks we need to delete from S3 and then reuse that query expression in the IN clause of the delete_many, then we wouldn't need any limit.