### PR TITLE
Fix build on Nix 2.19+

### DIFF
--- a/attic/build.rs
+++ b/attic/build.rs
@@ -24,6 +24,9 @@ fn build_bridge() {
         .flag("nix/config.h")
         .flag("-idirafter")
         .flag(hacky_include.path().to_str().unwrap())
+        // In Nix 2.19+, nix/args/root.hh depends on being able to #include "root.hh" (which is in its parent directory), for some reason
+        .flag("-I")
+        .flag(concat!(env!("NIX_INCLUDE_PATH"), "/nix"))
         .compile("nixbinding");
 
     println!("cargo:rerun-if-changed=src/nix_store/bindings");

--- a/crane.nix
+++ b/crane.nix
@@ -62,6 +62,9 @@ let
 
     ATTIC_DISTRIBUTOR = "attic";
 
+    # See comment in `attic/build.rs`
+    NIX_INCLUDE_PATH = "${lib.getDev nix}/include";
+
     # See comment in `attic-tests`
     doCheck = false;
 
@@ -135,6 +138,9 @@ let
     buildPhaseCargoCommand = "";
     checkPhaseCargoCommand = "cargoWithProfile test --no-run --message-format=json >cargo-test.json";
     doInstallCargoArtifacts = false;
+
+    # See comment in `attic/build.rs`
+    NIX_INCLUDE_PATH = "${lib.getDev nix}/include";
 
     installPhase = ''
       runHook preInstall

--- a/crane.nix
+++ b/crane.nix
@@ -62,11 +62,6 @@ let
 
     ATTIC_DISTRIBUTOR = "attic";
 
-    # Workaround for https://github.com/NixOS/nixpkgs/issues/166205
-    env = lib.optionalAttrs stdenv.cc.isClang {
-      NIX_LDFLAGS = "-l${stdenv.cc.libcxx.cxxabi.libName}";
-    };
-
     # See comment in `attic-tests`
     doCheck = false;
 
@@ -134,11 +129,6 @@ let
     inherit src version buildInputs cargoArtifacts;
 
     nativeBuildInputs = nativeBuildInputs ++ [ jq ];
-
-    # Workaround for https://github.com/NixOS/nixpkgs/issues/166205
-    env = lib.optionalAttrs stdenv.cc.isClang {
-      NIX_LDFLAGS = "-l${stdenv.cc.libcxx.cxxabi.libName}";
-    };
 
     doCheck = true;
 

--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702539185,
-        "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
+        "lastModified": 1711401922,
+        "narHash": "sha256-QoQqXoj8ClGo0sqD/qWKFWezgEwUL0SUh37/vY2jNhc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa9d4729cbc99dabacb50e3994dcefb3ea0f7447",
+        "rev": "07262b18b97000d16a4bdb003418bd2fb067a932",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1702780907,
-        "narHash": "sha256-blbrBBXjjZt6OKTcYX1jpe9SRof2P9ZYWPzq22tzXAA=",
+        "lastModified": 1711460390,
+        "narHash": "sha256-akSgjDZL6pVHEfSE6sz1DNSXuYX6hq+P/1Z5IoYWs7E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e2e384c5b7c50dbf8e9c441a9e58d85f408b01f",
+        "rev": "44733514b72e732bd49f5511bd0203dea9b9a434",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -130,6 +130,9 @@
         NIX_PATH = "nixpkgs=${pkgs.path}";
         RUST_SRC_PATH = "${pkgs.rustPlatform.rustcSrc}/library";
 
+        # See comment in `attic/build.rs`
+        NIX_INCLUDE_PATH = "${lib.getDev pkgs.nix}/include";
+
         ATTIC_DISTRIBUTOR = "dev";
       };
 

--- a/package.nix
+++ b/package.nix
@@ -49,11 +49,6 @@ in rustPlatform.buildRustPackage rec {
 
   ATTIC_DISTRIBUTOR = "attic";
 
-  # Workaround for https://github.com/NixOS/nixpkgs/issues/166205
-  env = lib.optionalAttrs stdenv.cc.isClang {
-    NIX_LDFLAGS = "-l${stdenv.cc.libcxx.cxxabi.libName}";
-  };
-
   # Recursive Nix is not stable yet
   doCheck = false;
 

--- a/package.nix
+++ b/package.nix
@@ -49,6 +49,9 @@ in rustPlatform.buildRustPackage rec {
 
   ATTIC_DISTRIBUTOR = "attic";
 
+  # See comment in `attic/build.rs`
+  NIX_INCLUDE_PATH = "${lib.getDev nix}/include";
+
   # Recursive Nix is not stable yet
   doCheck = false;
 


### PR DESCRIPTION
Nix 2.19 introduced a change [0] that broke how we compile our libnixstore bindings, which requires adding an additional include directory when we compile them.

I also included a semi-related maintenance change that I had to apply when fixing this, let me know if you'd rather pull those in from a separate PR.

[0]: https://github.com/NixOS/nix/commit/b461cac21aa5b9127d230ed3f1a1ca8e8266fb60