### PR TITLE
token: switch to using IndexMap for consistent ordering of entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "base64 0.21.5",
  "chrono",
  "displaydoc",
+ "indexmap 2.2.6",
  "jwt-simple",
  "lazy_static",
  "regex",
@@ -2204,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -3680,7 +3681,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -3705,7 +3706,7 @@ version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -3912,7 +3913,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "log",
  "memchr",
  "once_cell",
@@ -4404,7 +4405,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -11,6 +11,7 @@ attic = { path = "../attic", default-features = false }
 base64 = "0.21.2"
 chrono = "0.4.24"
 displaydoc = "0.2.4"
+indexmap = { version = "2.2.6", features = ["serde"] }
 jwt-simple = "0.11.5"
 lazy_static = "1.4.0"
 regex = "1.8.3"

--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -83,12 +83,12 @@ pub mod util;
 #[cfg(test)]
 mod tests;
 
-use std::collections::HashMap;
 use std::error::Error as StdError;
 
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
 use chrono::{DateTime, Utc};
 use displaydoc::Display;
+use indexmap::IndexMap;
 pub use jwt_simple::{
     algorithms::{HS256Key, MACLike},
     claims::{Claims, JWTClaims},
@@ -146,7 +146,7 @@ pub struct AtticAccess {
     /// Cache permissions.
     ///
     /// Keys here may include wildcards.
-    caches: HashMap<CacheNamePattern, CachePermission>,
+    caches: IndexMap<CacheNamePattern, CachePermission>,
 }
 
 /// Permission to a single cache.
@@ -274,7 +274,7 @@ impl Token {
         &mut self,
         pattern: CacheNamePattern,
     ) -> &mut CachePermission {
-        use std::collections::hash_map::Entry;
+        use indexmap::map::Entry;
 
         let access = self.attic_access_mut();
         match access.caches.entry(pattern) {


### PR DESCRIPTION
I added a test first, so that this kind of issue cannot happen again. If you check out this PR and run the tests before and after the switch to `IndexMap`, you should get a test failure before and a test success after.

See also https://github.com/zhaofengli/attic/issues/133 for an issue that was caused by the random ordering from a HashMap.

Closes #133.