### PR TITLE
ci-installer: Remove drvPath from fake derivation

### DIFF
--- a/.github/install-attic-ci.sh
+++ b/.github/install-attic-ci.sh
@@ -25,7 +25,6 @@ let
           value = common // {
             inherit outputName;
             outPath = maybeStorePath (builtins.getAttr outputName outputs);
-            drvPath = maybeStorePath (builtins.getAttr outputName outputs);
           };
         };
       outputsList = map outputToAttrListElement outputNames;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11
+          - macos-latest
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/ci-installer.nix
+++ b/ci-installer.nix
@@ -31,7 +31,6 @@ let
               value = common // {
                 inherit outputName;
                 outPath = maybeStorePath (builtins.getAttr outputName outputs);
-                drvPath = maybeStorePath (builtins.getAttr outputName outputs);
               };
             };
           outputsList = map outputToAttrListElement outputNames;


### PR DESCRIPTION
Also hotfixes the current install-attic-ci.sh.

Fixes #145.