### PR TITLE
attic-client: fix build against Nix 2.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+        nix:
+          - "2.20"
+          - "2.24"
+          - "default"
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -45,7 +49,7 @@ jobs:
         run: |
           system=$(nix-instantiate --eval -E 'builtins.currentSystem')
           echo system=$system >>$GITHUB_ENV
-          tests=$(nix build .#internal."$system".attic-tests --no-link --print-out-paths -L)
+          tests=$(nix build .#internalMatrix."$system".\"${{ matrix.nix }}\".attic-tests --no-link --print-out-paths -L)
           find "$tests/bin" -exec {} \;
 
       # TODO: Just take a diff of the list of store paths, also abstract all of this out
@@ -53,8 +57,10 @@ jobs:
         run: |
           export PATH=$HOME/.nix-profile/bin:$PATH # FIXME
           if [ -n "$ATTIC_TOKEN" ]; then
-            nix build .#internal."$system".attic-tests .#internal."$system".cargoArtifacts --no-link --print-out-paths -L | \
-              xargs attic push "ci:$ATTIC_CACHE"
+            nix build --no-link --print-out-paths -L \
+              .#internalMatrix."$system".\"${{ matrix.nix }}\".attic-tests \
+              .#internalMatrix."$system".\"${{ matrix.nix }}\".cargoArtifacts \
+            | xargs attic push "ci:$ATTIC_CACHE"
           fi
       - name: Log in to the Container registry
         uses: docker/login-action@v3.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "async-stream",
  "base64 0.22.1",
  "bytes",
+ "cc",
  "cxx",
  "cxx-build",
  "digest",
@@ -250,6 +251,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-test",
+ "version-compare",
  "wildmatch",
  "xdg",
 ]
@@ -1050,13 +1052,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -3961,6 +3963,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4890,6 +4898,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"

--- a/attic/Cargo.toml
+++ b/attic/Cargo.toml
@@ -43,9 +43,11 @@ serde_json = "1.0.96"
 tokio-test = "0.4.2"
 
 [build-dependencies]
+cc = "1.1.13"
 cxx-build = { version = "1.0", optional = true }
 pkg-config = "0.3.27"
 tempfile = "3"
+version-compare = "0.2.0"
 
 [features]
 default = [ "nix_store", "tokio" ]

--- a/attic/build.rs
+++ b/attic/build.rs
@@ -2,6 +2,47 @@
 //!
 //! We link against libnixstore to perform actions on the Nix Store.
 
+use cc::Build;
+use version_compare::Version;
+
+struct NixDependency {
+    version: String,
+}
+
+impl NixDependency {
+    fn detect() -> Self {
+        let library = pkg_config::Config::new()
+            .cargo_metadata(false)
+            .atleast_version("2.4")
+            .probe("nix-main")
+            .expect("Failed to find nix-main >=2.4 through pkg-config");
+
+        Self {
+            version: library.version,
+        }
+    }
+
+    fn apply_version_flags(&self, build: &mut Build) {
+        let version = Version::from(&self.version).unwrap();
+
+        if version >= Version::from("2.20").unwrap() {
+            build.flag("-DATTIC_NIX_2_20");
+        }
+    }
+
+    fn emit_cargo_metadata(&self) {
+        pkg_config::Config::new()
+            .atleast_version("2.4")
+            .probe("nix-store")
+            .unwrap();
+
+        pkg_config::Config::new()
+            .atleast_version("2.4")
+            .probe("nix-main")
+            .unwrap();
+    }
+}
+
 fn main() {
     #[cfg(feature = "nix_store")]
     build_bridge();
@@ -9,6 +50,8 @@ fn main() {
 
 #[cfg(feature = "nix_store")]
 fn build_bridge() {
+    let nix_dep = NixDependency::detect();
+
     // Temporary workaround for issue in <https://github.com/NixOS/nix/pull/8484>
     let hacky_include = {
         let dir = tempfile::tempdir().expect("Failed to create temporary directory for workaround");
@@ -16,7 +59,8 @@ fn build_bridge() {
         dir
     };
 
-    cxx_build::bridge("src/nix_store/bindings/mod.rs")
+    let mut build = cxx_build::bridge("src/nix_store/bindings/mod.rs");
+    build
         .file("src/nix_store/bindings/nix.cpp")
         .flag("-std=c++2a")
         .flag("-O2")
@@ -26,19 +70,14 @@ fn build_bridge() {
         .flag(hacky_include.path().to_str().unwrap())
         // In Nix 2.19+, nix/args/root.hh depends on being able to #include "args.hh" (which is in its parent directory), for some reason
         .flag("-I")
-        .flag(concat!(env!("NIX_INCLUDE_PATH"), "/nix"))
-        .compile("nixbinding");
+        .flag(concat!(env!("NIX_INCLUDE_PATH"), "/nix"));
+
+    nix_dep.apply_version_flags(&mut build);
+
+    build.compile("nixbinding");
 
     println!("cargo:rerun-if-changed=src/nix_store/bindings");
 
     // the -l flags must be after -lnixbinding
-    pkg_config::Config::new()
-        .atleast_version("2.4")
-        .probe("nix-store")
-        .unwrap();
-
-    pkg_config::Config::new()
-        .atleast_version("2.4")
-        .probe("nix-main")
-        .unwrap();
+    nix_dep.emit_cargo_metadata();
 }

--- a/attic/src/nix_store/bindings/nix.cpp
+++ b/attic/src/nix_store/bindings/nix.cpp
@@ -18,6 +18,14 @@ static nix::StorePath store_path_from_rust(RBasePathSlice base_name) {
 	return nix::StorePath(sv);
 }
 
+static bool hash_is_sha256(const nix::Hash &hash) {
+#ifdef ATTIC_NIX_2_20
+	return hash.algo == nix::HashAlgorithm::SHA256;
+#else
+	return hash.type == nix::htSHA256;
+#endif
+}
+
 // ========
 // RustSink
 // ========
@@ -44,7 +52,7 @@ CPathInfo::CPathInfo(nix::ref<const nix::ValidPathInfo> pi) : pi(pi) {}
 RHashSlice CPathInfo::nar_sha256_hash() {
 	auto &hash = this->pi->narHash;
 
-	if (hash.type != nix::htSHA256) {
+	if (!hash_is_sha256(hash)) {
 		throw nix::Error("Only SHA-256 hashes are supported at the moment");
 	}
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717025063,
-        "narHash": "sha256-dIubLa56W9sNNz0e8jGxrX3CAkPXsq7snuFA/Ie6dn8=",
+        "lastModified": 1722960479,
+        "narHash": "sha256-NhCkJJQhD5GUib8zN9JrmYGMwt4lCRp6ZVNzIiYCl0Y=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "480dff0be03dac0e51a8dfc26e882b0d123a450e",
+        "rev": "4c6c77920b8d44cd6660c1621dea6b3fc4b4c4f4",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -37,12 +37,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -53,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711401922,
-        "narHash": "sha256-QoQqXoj8ClGo0sqD/qWKFWezgEwUL0SUh37/vY2jNhc=",
+        "lastModified": 1723827930,
+        "narHash": "sha256-EU+W5F6y2CVNxGrGIMpY7nSVYq72WRChYxF4zpjx0y4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "07262b18b97000d16a4bdb003418bd2fb067a932",
+        "rev": "d4a7a4d0e066278bfb0d77bd2a7adde1c0ec9e3d",
         "type": "github"
       },
       "original": {
@@ -69,11 +72,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1711460390,
-        "narHash": "sha256-akSgjDZL6pVHEfSE6sz1DNSXuYX6hq+P/1Z5IoYWs7E=",
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44733514b72e732bd49f5511bd0203dea9b9a434",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
         "type": "github"
       },
       "original": {
@@ -90,6 +93,21 @@
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-stable": "nixpkgs-stable"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,16 @@
     };
     cranePkgs = makeCranePkgs pkgs;
 
+    internalMatrix = lib.mapAttrs (_: nix: let
+      cranePkgs' = cranePkgs.override { inherit nix; };
+    in {
+      inherit (cranePkgs') attic-tests cargoArtifacts;
+    }) {
+      "2.20" = pkgs.nixVersions.nix_2_20;
+      "2.24" = pkgs.nixVersions.nix_2_24;
+      "default" = pkgs.nix;
+    };
+
     pkgsStable = import nixpkgs-stable {
       inherit system;
       overlays = [];
@@ -38,6 +48,8 @@
 
     inherit (pkgs) lib;
   in rec {
+    inherit internalMatrix;
+
     packages = {
       default = packages.attic;
 
@@ -152,10 +164,6 @@
       };
     };
     devShell = devShells.default;
-
-    internal = {
-      inherit (cranePkgs) attic-tests cargoArtifacts;
-    };
 
     checks = let
       makeIntegrationTests = pkgs: import ./integration-tests {

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,10 @@
           rustc
 
           rustfmt clippy
-          cargo-expand cargo-outdated cargo-edit
+          cargo-expand
+          # Temporary broken: https://github.com/NixOS/nixpkgs/pull/335152
+          # cargo-outdated
+          cargo-edit
           tokio-console
 
           sqlite-interactive
@@ -131,7 +134,7 @@
         RUST_SRC_PATH = "${pkgs.rustPlatform.rustcSrc}/library";
 
         # See comment in `attic/build.rs`
-        NIX_INCLUDE_PATH = "${lib.getDev pkgs.nix}/include";
+        NIX_INCLUDE_PATH = "${lib.getDev pkgs.nixVersions.nix_2_24}/include";
 
         ATTIC_DISTRIBUTOR = "dev";
       };


### PR DESCRIPTION
The way I had to upgrade nix 2.24 is a bit hacky especially since it's not in nixos 24.05.
