### PR TITLE
Update nix-base32 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,8 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "nix-base32"
-version = "0.1.2-alpha.0"
-source = "git+https://github.com/zhaofengli/nix-base32.git?rev=b850c6e9273d1c39bd93abb704a53345f5be92eb#b850c6e9273d1c39bd93abb704a53345f5be92eb"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2628953ed836273ee4262e3708a8ef63ca38bd8a922070626eef7f9e5d8d536"
 
 [[package]]
 name = "nom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,6 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
- "tokio-test",
  "version-compare",
  "wildmatch",
  "xdg",

--- a/attic/Cargo.toml
+++ b/attic/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3.28"
 hex = "0.4.3"
 lazy_static = "1.4.0"
 log = "0.4.18"
-nix-base32 = { git = "https://github.com/zhaofengli/nix-base32.git", rev = "b850c6e9273d1c39bd93abb704a53345f5be92eb" }
+nix-base32 = "0.2.0"
 regex = "1.8.3"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_yaml = "0.9.21"

--- a/attic/Cargo.toml
+++ b/attic/Cargo.toml
@@ -76,7 +76,7 @@ nix_store = [
 stream = ["tokio", "dep:async-stream"]
 
 # Tokio runtime.
-tokio = ["dep:tokio", "tokio/rt"]
+tokio = ["dep:tokio", "tokio/rt", "tokio/time"]
 
 [[bench]]
 name = "chunking"


### PR DESCRIPTION
Remove the git dependency now that upstream has release 0.2.0.