### PR TITLE
flake.nix: Use default Nix headers in devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -149,7 +149,7 @@
         RUST_SRC_PATH = "${pkgs.rustPlatform.rustcSrc}/library";
 
         # See comment in `attic/build.rs`
-        NIX_INCLUDE_PATH = "${lib.getDev pkgs.nixVersions.nix_2_24}/include";
+        NIX_INCLUDE_PATH = "${lib.getDev pkgs.nix}/include";
 
         ATTIC_DISTRIBUTOR = "dev";
       };


### PR DESCRIPTION
Missed this when modifying #159. Fixes mixing different versions of headers and libraries.

There will be a convenient way to test different Nix versions in the devShell soon.