### PR TITLE
attic-client/push: Add flag to read paths from stdin

### DIFF
--- a/client/src/command/push.rs
+++ b/client/src/command/push.rs
@@ -26,8 +26,8 @@ pub struct Push {
     /// The store paths to push.
     paths: Vec<PathBuf>,
 
-    /// Read paths from stdin
-    #[clap(short = 'i', long)]
+    /// Read paths from the standard input.
+    #[clap(long)]
     stdin: bool,
 
     /// Push the specified paths only and do not compute closures.

--- a/client/src/push.rs
+++ b/client/src/push.rs
@@ -28,7 +28,7 @@ use bytes::Bytes;
 use futures::future::join_all;
 use futures::stream::{Stream, TryStreamExt};
 use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressState, ProgressStyle};
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tokio::task::{spawn, JoinHandle};
 use tokio::time;
 
@@ -101,16 +101,21 @@ pub struct Pusher {
 pub struct PushSession {
     /// Sender to the batching future.
     sender: channel::Sender<SessionQueueCommand>,
+
+    /// Receiver of results.
+    result_receiver: mpsc::Receiver<Result<HashMap<StorePath, Result<()>>>>,
 }
 
 enum SessionQueueCommand {
     Paths(Vec<StorePath>),
     Flush,
+    Terminate,
 }
 
 enum SessionQueuePoll {
     Paths(Vec<StorePath>),
     Flush,
+    Terminate,
     Closed,
     TimedOut,
 }
@@ -261,36 +266,36 @@ impl Pusher {
 impl PushSession {
     pub fn with_pusher(pusher: Pusher, config: PushSessionConfig) -> Self {
         let (sender, receiver) = channel::unbounded();
+        let (result_sender, result_receiver) = mpsc::channel(1);
 
         let known_paths_mutex = Arc::new(Mutex::new(HashSet::new()));
 
-        // FIXME
         spawn(async move {
-            let pusher = Arc::new(pusher);
-            loop {
-                if let Err(e) = Self::worker(
-                    pusher.clone(),
-                    config,
-                    known_paths_mutex.clone(),
-                    receiver.clone(),
-                )
-                .await
-                {
-                    eprintln!("Worker exited: {:?}", e);
-                } else {
-                    break;
-                }
+            if let Err(e) = Self::worker(
+                pusher,
+                config,
+                known_paths_mutex.clone(),
+                receiver.clone(),
+                result_sender.clone(),
+            )
+            .await
+            {
+                let _ = result_sender.send(Err(e)).await;
             }
         });
 
-        Self { sender }
+        Self {
+            sender,
+            result_receiver,
+        }
     }
 
     async fn worker(
-        pusher: Arc<Pusher>,
+        pusher: Pusher,
         config: PushSessionConfig,
         known_paths_mutex: Arc<Mutex<HashSet<StorePathHash>>>,
         receiver: channel::Receiver<SessionQueueCommand>,
+        result_sender: mpsc::Sender<Result<HashMap<StorePath, Result<()>>>>,
     ) -> Result<()> {
         let mut roots = HashSet::new();
 
@@ -304,6 +309,7 @@ impl PushSession {
                             r = receiver.recv() => match r {
                                 Ok(SessionQueueCommand::Paths(paths)) => SessionQueuePoll::Paths(paths),
                                 Ok(SessionQueueCommand::Flush) => SessionQueuePoll::Flush,
+                                Ok(SessionQueueCommand::Terminate) => SessionQueuePoll::Terminate,
                                 _ => SessionQueuePoll::Closed,
                             },
                             _ = time::sleep(Duration::from_secs(2)) => SessionQueuePoll::TimedOut,
@@ -313,7 +319,7 @@ impl PushSession {
                             SessionQueuePoll::Paths(store_paths) => {
                                 roots.extend(store_paths.into_iter());
                             }
-                            SessionQueuePoll::Closed => {
+                            SessionQueuePoll::Closed | SessionQueuePoll::Terminate => {
                                 break true;
                             }
                             SessionQueuePoll::Flush | SessionQueuePoll::TimedOut => {
@@ -359,9 +365,24 @@ impl PushSession {
             drop(known_paths);
 
             if done {
+                let result = pusher.wait().await;
+                result_sender.send(Ok(result)).await?;
                 return Ok(());
             }
         }
+    }
+
+    /// Waits for all workers to terminate, returning all results.
+    pub async fn wait(mut self) -> Result<HashMap<StorePath, Result<()>>> {
+        self.flush()?;
+
+        // The worker might have died
+        let _ = self.sender.send(SessionQueueCommand::Terminate).await;
+
+        self.result_receiver
+            .recv()
+            .await
+            .expect("Nothing in result channel")
     }
 
     /// Queues multiple store paths to be pushed.


### PR DESCRIPTION
This adds a new flag (`-i`/`--stdin`) to the `push` subcommand of the attic client. This would  resolve #175 .

Note that there is also #118 , which implements a similar behavior as a fallback for the `push` command.