### PR TITLE
token: Don't require valid UTF-8 for HS256 secrets

### DIFF
--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -444,8 +444,7 @@ impl StdError for Error {}
 
 pub fn decode_token_hs256_secret_base64(s: &str) -> Result<HS256Key> {
     let decoded = BASE64_STANDARD.decode(s).map_err(Error::Base64Error)?;
-    let secret = std::str::from_utf8(&decoded).map_err(Error::Utf8Error)?;
-    Ok(HS256Key::from_bytes(&secret.as_bytes()))
+    Ok(HS256Key::from_bytes(&decoded))
 }
 
 pub fn decode_token_rs256_secret_base64(s: &str) -> Result<RS256KeyPair> {

--- a/token/src/tests.rs
+++ b/token/src/tests.rs
@@ -32,11 +32,11 @@ fn test_basic() {
         (
             "hs256",
             Box::new(|| {
-                // "very secure secret"
-                let base64_secret = "dmVyeSBzZWN1cmUgc2VjcmV0";
+                // printf '\xc3\x28 <- invalid utf8' | base64
+                let base64_secret = "wyggPC0gaW52YWxpZCB1dGY4";
                 let dec_key = decode_token_hs256_secret_base64(base64_secret).unwrap();
 
-                let token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjQxMDIzMjQ5ODYsImh0dHBzOi8vand0LmF0dGljLnJzL3YxIjp7ImNhY2hlcyI6eyJhbGwtKiI6eyJyIjoxfSwiYWxsLWNpLSoiOnsidyI6MX0sImNhY2hlLXJvIjp7InIiOjF9LCJjYWNoZS1ydyI6eyJyIjoxLCJ3IjoxfSwidGVhbS0qIjp7ImNjIjoxLCJyIjoxLCJ3IjoxfX19LCJpYXQiOjE3MTY2NjA1ODksInN1YiI6Im1lb3cifQ.8vtxp_1OEYdcnkGPM4c9ORXooJZV7DOTS4NRkMKN8mw";
+                let token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjQxMDIzMjQ5ODYsImh0dHBzOi8vand0LmF0dGljLnJzL3YxIjp7ImNhY2hlcyI6eyJhbGwtKiI6eyJyIjoxfSwiYWxsLWNpLSoiOnsidyI6MX0sImNhY2hlLXJvIjp7InIiOjF9LCJjYWNoZS1ydyI6eyJyIjoxLCJ3IjoxfSwidGVhbS0qIjp7ImNjIjoxLCJyIjoxLCJ3IjoxfX19LCJpYXQiOjE3MjgyMzI5OTYsIm5iZiI6MCwic3ViIjoibWVvdyJ9.wESluTI5K5v2W1WISGwAjazKMMUZBD-zSUYN-_XFN9I";
 
                 Token::from_jwt(token, &SignatureType::HS256(dec_key), &None, &None).unwrap()
             }),


### PR DESCRIPTION
Regression from #177 that erroneously required HS256 secrets to be valid UTF-8. Also fail fast on token decoding errors instead of silently ignoring them.

Fixes #180.