### PR TITLE
nixos: Switch back to setting a placeholder HS256 secret

### DIFF
--- a/nixos/atticd.nix
+++ b/nixos/atticd.nix
@@ -16,7 +16,7 @@ let
   } ''
     cat $configFile
 
-    export ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64="$(${pkgs.openssl}/bin/openssl genrsa -traditional 4096 | ${pkgs.coreutils}/bin/base64 -w0)"
+    export ATTIC_SERVER_TOKEN_HS256_SECRET_BASE64="dGVzdCBzZWNyZXQ="
     export ATTIC_SERVER_DATABASE_URL="sqlite://:memory:"
     ${cfg.package}/bin/atticd --mode check-config -f $configFile
     cat <$configFile >$out


### PR DESCRIPTION
Some people are using the NixOS module in this repo with an older atticd from nixpkgs (#184). Since the NixOS module sets a placeholder RS256 secret which the nixpkgs version doesn't support, config checking breaks.

We don't want to support such use case in general, but in this specific case I think setting a hardcoded HS256 secret is nicer than generating an RS256 keypair every time.

---

To reiterate, the NixOS module in this repo is coupled to the atticd version here and mixing the versions is unsupported. This PR happens to make it work for the moment, but it may very well break in the future.