### PR TITLE
Display anyhow error chains better

### DIFF
--- a/server/src/api/binary_cache.rs
+++ b/server/src/api/binary_cache.rs
@@ -218,7 +218,7 @@ async fn get_nar(
             Download::Url(url) => Ok(Redirect::temporary(&url).into_response()),
             Download::AsyncRead(stream) => {
                 let stream = ReaderStream::new(stream).map_err(|e| {
-                    tracing::error!("Stream error: {e}");
+                    tracing::error!(%e, "Stream error");
                     e
                 });
                 let body = Body::from_stream(stream);
@@ -255,7 +255,7 @@ async fn get_nar(
         // TODO: Make num_prefetch configurable
         // The ideal size depends on the average chunk size
         let merged = merge_chunks(chunks, streamer, storage, 2).map_err(|e| {
-            tracing::error!("Stream error: {e}");
+            tracing::error!(%e, "Stream error");
             e
         });
         let body = Body::from_stream(merged);

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -57,10 +57,10 @@ pub enum ErrorKind {
     /// The requested NAR has missing chunks and needs to be repaired.
     IncompleteNar,
 
-    /// Database error: {0}
+    /// Database error: {0:#}
     DatabaseError(AnyError),
 
-    /// Storage error: {0}
+    /// Storage error: {0:#}
     StorageError(AnyError),
 
     /// Manifest serialization error: {0}
@@ -69,7 +69,7 @@ pub enum ErrorKind {
     /// Access error: {0}
     AccessError(super::access::Error),
 
-    /// General request error: {0}
+    /// General request error: {0:#}
     RequestError(AnyError),
 
     /// Error from the common components.


### PR DESCRIPTION
The default Display / `{}` formatter only shows the outermost error. We have to use `{:#}` to show all the errors in the chain. This will make stream errors somewhat more informational.

Before:

    Stream error: Storage error: service error

After:

    Stream error e=Storage error: service error: NoSuchKey: The specified key does not exist.: NoSuchKey: The specified key does not exist.

(after I manually mucked with the DB to change the S3 url for an item to a non-existent name)