### PR TITLE
nixos: Remove --same-dir in systemd-run invocation

### DIFF
--- a/nixos/atticd.nix
+++ b/nixos/atticd.nix
@@ -46,7 +46,6 @@ let
       --quiet \
       --pipe \
       --pty \
-      --same-dir \
       --wait \
       --collect \
       --service-type=exec \


### PR DESCRIPTION
`--working-directory /` was added in #26 but we forgot to remove `--same-dir`.

Fixes #201.