### PR TITLE
nixos: Allow settings to be omitted with null

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -105,6 +105,7 @@ pub struct Config {
     pub require_proof_of_possession: bool,
 
     /// Database connection.
+    #[serde(default = "Default::default")]
     pub database: DatabaseConfig,
 
     /// Storage.
@@ -416,6 +417,15 @@ fn load_database_url_from_env() -> String {
         "Database URL must be specified in either database.url \
         or the {ENV_DATABASE_URL} environment."
     ))
+}
+
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self {
+            url: load_database_url_from_env(),
+            heartbeat: default_db_heartbeat(),
+        }
+    }
 }
 
 impl Default for JWTConfig {


### PR DESCRIPTION
The `ATTIC_SERVER_DATABASE_URL`, `PGUSERNAME` and `PGPASSWORD` environment already work, but there are paper cuts when used from the NixOS module:

- The module sets `database.url` by default, which cannot easily suppressed if you intend to set `ATTIC_SERVER_DATABASE_URL`
- The server doesn't support the `[database]` section being omitted entirely

Alternative: Instead of allowing settings to be null in the module, we can add an `useSqlite`/`addSqliteDefaults` option that defaults to true.

In the future, we need to rethink about the precedence of configuration sources. It makes sense for the environment variables to take precedence over configuration files.

Closes #152.