### PR TITLE
fix application/x-nix-nar Content-Type not being applied

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,12 @@ jobs:
         run: |
           : "${ATTIC_SERVER:=https://staging.attic.rs/}"
           : "${ATTIC_CACHE:=attic-ci}"
-          echo ATTIC_CACHE=$ATTIC_CACHE >>$GITHUB_ENV
           export PATH=$HOME/.nix-profile/bin:$PATH # FIXME
           attic login --set-default ci "$ATTIC_SERVER" "$ATTIC_TOKEN"
           attic use "$ATTIC_CACHE"
+          if [ -n "$ATTIC_TOKEN" ]; then
+            echo ATTIC_CACHE=$ATTIC_CACHE >>$GITHUB_ENV
+          fi
         env:
           ATTIC_SERVER: ${{ secrets.ATTIC_SERVER }}
           ATTIC_CACHE: ${{ secrets.ATTIC_CACHE }}
@@ -97,10 +99,12 @@ jobs:
         run: |
           : "${ATTIC_SERVER:=https://staging.attic.rs/}"
           : "${ATTIC_CACHE:=attic-ci}"
-          echo ATTIC_CACHE=$ATTIC_CACHE >>$GITHUB_ENV
           export PATH=$HOME/.nix-profile/bin:$PATH # FIXME
           attic login --set-default ci "$ATTIC_SERVER" "$ATTIC_TOKEN"
           attic use "$ATTIC_CACHE"
+          if [ -n "$ATTIC_TOKEN" ]; then
+            echo ATTIC_CACHE=$ATTIC_CACHE >>$GITHUB_ENV
+          fi
         env:
           ATTIC_SERVER: ${{ secrets.ATTIC_SERVER }}
           ATTIC_CACHE: ${{ secrets.ATTIC_CACHE }}
@@ -152,10 +156,12 @@ jobs:
         run: |
           : "${ATTIC_SERVER:=https://staging.attic.rs/}"
           : "${ATTIC_CACHE:=attic-ci}"
-          echo ATTIC_CACHE=$ATTIC_CACHE >>$GITHUB_ENV
           export PATH=$HOME/.nix-profile/bin:$PATH # FIXME
           attic login --set-default ci "$ATTIC_SERVER" "$ATTIC_TOKEN"
           attic use "$ATTIC_CACHE"
+          if [ -n "$ATTIC_TOKEN" ]; then
+            echo ATTIC_CACHE=$ATTIC_CACHE >>$GITHUB_ENV
+          fi
         env:
           ATTIC_SERVER: ${{ secrets.ATTIC_SERVER }}
           ATTIC_CACHE: ${{ secrets.ATTIC_CACHE }}
@@ -197,10 +203,12 @@ jobs:
         run: |
           : "${ATTIC_SERVER:=https://staging.attic.rs/}"
           : "${ATTIC_CACHE:=attic-ci}"
-          echo ATTIC_CACHE=$ATTIC_CACHE >>$GITHUB_ENV
           export PATH=$HOME/.nix-profile/bin:$PATH # FIXME
           attic login --set-default ci "$ATTIC_SERVER" "$ATTIC_TOKEN"
           attic use "$ATTIC_CACHE"
+          if [ -n "$ATTIC_TOKEN" ]; then
+            echo ATTIC_CACHE=$ATTIC_CACHE >>$GITHUB_ENV
+          fi
         env:
           ATTIC_SERVER: ${{ secrets.ATTIC_SERVER }}
           ATTIC_CACHE: ${{ secrets.ATTIC_CACHE }}
@@ -246,10 +254,12 @@ jobs:
         run: |
           : "${ATTIC_SERVER:=https://staging.attic.rs/}"
           : "${ATTIC_CACHE:=attic-ci}"
-          echo ATTIC_CACHE=$ATTIC_CACHE >>$GITHUB_ENV
           export PATH=$HOME/.nix-profile/bin:$PATH # FIXME
           attic login --set-default ci "$ATTIC_SERVER" "$ATTIC_TOKEN"
           attic use "$ATTIC_CACHE"
+          if [ -n "$ATTIC_TOKEN" ]; then
+            echo ATTIC_CACHE=$ATTIC_CACHE >>$GITHUB_ENV
+          fi
         env:
           ATTIC_SERVER: ${{ secrets.ATTIC_SERVER }}
           ATTIC_CACHE: ${{ secrets.ATTIC_CACHE }}

--- a/server/src/api/binary_cache.rs
+++ b/server/src/api/binary_cache.rs
@@ -9,6 +9,7 @@ use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use axum::http;
 use axum::{
     body::Body,
     extract::{Extension, Path},
@@ -223,7 +224,14 @@ async fn get_nar(
                 });
                 let body = Body::from_stream(stream);
 
-                Ok(body.into_response())
+                Ok((
+                    [(
+                        http::header::CONTENT_TYPE,
+                        http::HeaderValue::from_static(mime::NAR),
+                    )],
+                    body,
+                )
+                    .into_response())
             }
         }
     } else {
@@ -260,7 +268,14 @@ async fn get_nar(
         });
         let body = Body::from_stream(merged);
 
-        Ok(body.into_response())
+        Ok((
+            [(
+                http::header::CONTENT_TYPE,
+                http::HeaderValue::from_static(mime::NAR),
+            )],
+            body,
+        )
+            .into_response())
     }
 }
 


### PR DESCRIPTION
Probably not the cleanest way to do it, but it worked based on my testing and I was trying to figure out an (unrelated) issue that could have had something to do with the Content-Type always being `application/octet-stream` from Attic. Just sending this anyways because it seems unintended for this to always be `application/octet-stream` compared to other Nix binary caches out there that do send `application/x-nix-nar`.