### PR TITLE
attic for attic - (add substituter to nixConfig in flake.nix)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,4 +53,11 @@
 
     debug = true;
   };
+
+
+  nixConfig = {
+    extra-substituters = [ "https://attic.tam.ma/attic" ];
+    extra-trusted-public-keys = [ "attic:Dc088G5QEZnihlLq73D4RWw8PbQ+SIe0UHslzqXdULs=" ];
+  };
+  
 }


### PR DESCRIPTION
I want to use attic in many places (e.g. servers, CI) - but building it bothers me: it takes 20 minutes on some machines 😲

Now shouldn't attic have an attic cache?
I'm guessing from reading the GH Action logs that you might be using one, but it would be great if one were configured as substituter in flake.nix, as in this PR (example - it's pointing to my attic).

What you you think?