### PR TITLE
attic/nix_store: Update bindings for Nix 2.28

### DIFF
--- a/attic/build.rs
+++ b/attic/build.rs
@@ -21,7 +21,9 @@ mod nix_store {
 
         build.define("ATTIC_VARIANT_NIX", None);
 
-        let version = if version >= Version::from("2.26").unwrap() {
+        let version = if version >= Version::from("2.28").unwrap() {
+            228
+        } else if version >= Version::from("2.26").unwrap() {
             226
         } else {
             225

--- a/attic/src/nix_store/bindings/nix-includes.hpp
+++ b/attic/src/nix_store/bindings/nix-includes.hpp
@@ -1,19 +1,30 @@
 #if defined(ATTIC_VARIANT_NIX)
-	#if NIX_VERSION >= 226
-		#include <nix/config-main.hh>
-		#include <nix/config-store.hh>
+    #if NIX_VERSION >= 228
+		#include <nix/main/shared.hh>
+		#include <nix/store/local-store.hh>
+		#include <nix/store/path.hh>
+		#include <nix/store/remote-store.hh>
+		#include <nix/store/store-api.hh>
+		#include <nix/store/uds-remote-store.hh>
+		#include <nix/util/hash.hh>
+		#include <nix/util/serialise.hh>
 	#else
-		#include <nix/config.h>
-	#endif
+		#if NIX_VERSION >= 226
+			#include <nix/config-main.hh>
+			#include <nix/config-store.hh>
+		#else
+			#include <nix/config.h>
+		#endif
 
-	#include <nix/store-api.hh>
-	#include <nix/local-store.hh>
-	#include <nix/remote-store.hh>
-	#include <nix/uds-remote-store.hh>
-	#include <nix/hash.hh>
-	#include <nix/path.hh>
-	#include <nix/serialise.hh>
-	#include <nix/shared.hh>
+		#include <nix/store-api.hh>
+		#include <nix/local-store.hh>
+		#include <nix/remote-store.hh>
+		#include <nix/uds-remote-store.hh>
+		#include <nix/hash.hh>
+		#include <nix/path.hh>
+		#include <nix/serialise.hh>
+		#include <nix/shared.hh>
+	#endif
 #else
 	#error Unsupported variant
 #endif


### PR DESCRIPTION
We've made some changes to the headers, to make them more reliable, and so that the generated headers are handled behind the scenes instead of exposing that complexity.

This commit does not include the actual update yet, but I've built it against a draft Nixpkgs update. Also I've pointed it to the `nix-2.26` branch for clarity.