### PR TITLE
attic-server: Make `MAX_NAR_INFO_SIZE` configurable

### DIFF
--- a/server/src/api/v1/upload_path.rs
+++ b/server/src/api/v1/upload_path.rs
@@ -55,11 +55,6 @@ use crate::database::{AtticDatabase, ChunkGuard, NarGuard};
 /// TODO: Make this configurable
 const CONCURRENT_CHUNK_UPLOADS: usize = 10;
 
-/// The maximum size of the upload info JSON.
-///
-/// TODO: Make this configurable
-const MAX_NAR_INFO_SIZE: usize = 1 * 1024 * 1024; // 1 MiB
-
 type CompressorFn<C> = Box<dyn FnOnce(C) -> Box<dyn AsyncRead + Unpin + Send> + Send>;
 
 /// Data of a chunk.
@@ -147,7 +142,7 @@ pub(crate) async fn upload_path(
                     ))
                 })?;
 
-            if preamble_size > MAX_NAR_INFO_SIZE {
+            if preamble_size > state.config.max_nar_info_size {
                 return Err(ErrorKind::RequestError(anyhow!("Upload info is too large")).into());
             }
 

--- a/server/src/config-template.toml
+++ b/server/src/config-template.toml
@@ -19,6 +19,9 @@ allowed-hosts = []
 # not `https://domain.tld/attic`).
 #api-endpoint = "https://your.domain.tld/"
 
+# The maximum size of the upload info JSON, in bytes.
+#max-nar-info-size = 1048576 # 1 MiB
+
 # Whether to soft-delete caches
 #
 # If this is enabled, caches are soft-deleted instead of actually

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -135,6 +135,11 @@ pub struct Config {
     #[serde(deserialize_with = "deserialize_deprecated_token_hs256_secret")]
     #[derivative(Debug = "ignore")]
     pub _depreated_token_hs256_secret: Option<String>,
+
+    /// The maximum size of the upload info JSON, in bytes.
+    #[serde(rename = "max-nar-info-size")]
+    #[serde(default = "default_max_nar_info_size")]
+    pub max_nar_info_size: usize,
 }
 
 /// JSON Web Token configuration.
@@ -556,6 +561,10 @@ fn default_gc_interval() -> Duration {
 
 fn default_default_retention_period() -> Duration {
     Duration::ZERO
+}
+
+fn default_max_nar_info_size() -> usize {
+    1 * 1024 * 1024 // 1 MiB
 }
 
 fn load_config_from_path(path: &Path) -> Result<Config> {


### PR DESCRIPTION
I was trying to push a json info file larger than the current `MAX_NAR_INFO_SIZE`, which failed. Made it configurable and tested it to work on the same file by setting the limit to 2 MiB in the server’s `toml` configuration.
