### PR TITLE
Enable configuring caches via config file

### DIFF
--- a/server/src/api/v1/cache_config.rs
+++ b/server/src/api/v1/cache_config.rs
@@ -11,7 +11,7 @@ use tracing::instrument;
 use crate::database::entity::Json as DbJson;
 use crate::database::entity::cache::{self, Entity as Cache};
 use crate::error::{ErrorKind, ServerError, ServerResult};
-use crate::{RequestState, State};
+use crate::{RequestState, State, StateInner};
 use attic::api::v1::cache_config::{
     CacheConfig, CreateCacheRequest, KeypairConfig, RetentionPeriodConfig,
 };
@@ -61,6 +61,7 @@ pub(crate) async fn configure_cache(
     Path(cache_name): Path<CacheName>,
     Json(payload): Json<CacheConfig>,
 ) -> ServerResult<()> {
+    check_declarative(&state)?;
     let database = state.database().await?;
     let (cache, permission) = req_state
         .auth
@@ -142,6 +143,7 @@ pub(crate) async fn destroy_cache(
     Extension(req_state): Extension<RequestState>,
     Path(cache_name): Path<CacheName>,
 ) -> ServerResult<()> {
+    check_declarative(&state)?;
     let database = state.database().await?;
     let cache = req_state
         .auth
@@ -192,6 +194,7 @@ pub(crate) async fn create_cache(
     Path(cache_name): Path<CacheName>,
     Json(payload): Json<CreateCacheRequest>,
 ) -> ServerResult<()> {
+    check_declarative(&state)?;
     let permission = req_state.auth.get_permission_for_cache(&cache_name, false);
     permission.require_create_cache()?;
 
@@ -224,6 +227,14 @@ pub(crate) async fn create_cache(
     if num_inserted == 0 {
         // The cache already exists
         Err(ErrorKind::CacheAlreadyExists.into())
+    } else {
+        Ok(())
+    }
+}
+
+fn check_declarative(state: &StateInner) -> ServerResult<()> {
+    if state.config.declarative {
+        Err(ErrorKind::DeclarativeCaches.into())
     } else {
         Ok(())
     }

--- a/server/src/config-template.toml
+++ b/server/src/config-template.toml
@@ -37,6 +37,9 @@ allowed-hosts = []
 # cache.
 #require-proof-of-possession = true
 
+# Whether caches not declared in the config file should be deleted
+#declarative = false
+
 # Database connection
 [database]
 # Connection URL
@@ -164,3 +167,41 @@ token-rs256-secret-base64 = "%token_rs256_secret_base64%"
 # You can also set it via the `ATTIC_SERVER_TOKEN_HS256_SECRET_BASE64`
 # environment variable.
 #token-hs256-secret-base64 = ""
+
+# Caches that should be automatically set up as configured
+#
+# If one of these caches is updated manually, then on the next migration
+# it will be restored to what is configured here
+#[caches.<name>]
+#  Whether the cache is public or not.
+#
+#  Anonymous clients are implicitly granted the "pull"
+#  permission to public caches.
+#public = false
+#
+# The retention period of the cache.
+# Unset will use the global default
+#retention-period = "6 months"
+#
+# The priority of the binary cache.
+#
+# A lower number denotes a higher priority.
+# <https://cache.nixos.org> has a priority of 40.
+#priority = 41
+#
+# A list of signing key names of upstream caches.
+#
+# The list serves as a hint to clients to avoid uploading
+# store paths signed with such keys.
+#upstream-cache-key-names = ["cache.nixos.org-1"]
+#
+# The signing keypair for the cache.
+#
+# If empty on initial creation, a new random keypair will be generated.
+# Provide via either of these two options:
+#
+# Use the keypair verbatim from the config
+#keypair = "<name>:<key>"
+#
+# Read the keypair from this path's file content
+#keypair-path = ""

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -1,13 +1,16 @@
 //! Server configuration.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::Result;
 use async_compression::Level as CompressionLevel;
+use attic::AtticResult;
+use attic::signing::NixKeypair;
 use attic_token::SignatureType;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use serde::{Deserialize, de};
@@ -128,6 +131,17 @@ pub struct Config {
     /// JSON Web Token.
     #[serde(default = "Default::default")]
     pub jwt: JWTConfig,
+
+    /// Caches that should be automatically set up as configured
+    ///
+    /// If one of these caches is updated manually, then on the next migration
+    /// it will be restored to what is configured here
+    #[serde(default = "Default::default")]
+    pub caches: HashMap<String, CacheConfig>,
+
+    /// Whether caches not declared in the config file should be deleted
+    #[serde(default = "Default::default")]
+    pub declarative: bool,
 
     /// (Deprecated Stub)
     ///
@@ -322,6 +336,76 @@ pub struct GarbageCollectionConfig {
     #[serde(rename = "default-retention-period")]
     #[serde(with = "humantime_serde", default = "default_default_retention_period")]
     pub default_retention_period: Duration,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CacheConfig {
+    /// Whether the cache is public or not.
+    ///
+    /// Anonymous clients are implicitly granted the "pull"
+    /// permission to public caches.
+    #[serde(default = "default_cache_visibility")]
+    pub public: bool,
+
+    /// The retention period of the cache.
+    /// Unset will use the global default
+    #[serde(with = "humantime_serde", default = "default_cache_retention_period")]
+    pub retention_period: Option<Duration>,
+
+    /// The priority of the binary cache.
+    ///
+    /// A lower number denotes a higher priority.
+    /// <https://cache.nixos.org> has a priority of 40.
+    #[serde(default = "default_cache_priority")]
+    pub priority: i32,
+
+    /// A list of signing key names of upstream caches.
+    ///
+    /// The list serves as a hint to clients to avoid uploading
+    /// store paths signed with such keys.
+    #[serde(default = "default_cache_upstream_cache_key_names")]
+    pub upstream_cache_key_names: Vec<String>,
+
+    /// The signing keypair for the cache.
+    ///
+    /// If empty on initial creation, a new random keypair will be generated.
+    #[serde(flatten, default)]
+    pub keypair: CacheKeypairConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged, rename_all = "kebab-case")]
+pub enum CacheKeypairConfig {
+    /// Use the keypair verbatim from the config
+    Inline {
+        keypair: String,
+    },
+    /// Read the keypair from this path's file content
+    Path {
+        keypair_path: String,
+    },
+    None {},
+}
+
+impl Default for CacheKeypairConfig {
+    fn default() -> Self {
+        Self::None {}
+    }
+}
+
+impl CacheKeypairConfig {
+    pub fn get_keypair(&self) -> Option<AtticResult<NixKeypair>> {
+        match self {
+            Self::Inline { keypair } => Some(NixKeypair::from_str(keypair)),
+            Self::Path { keypair_path } => Some(
+                std::fs::read_to_string(keypair_path)
+                    .map_err(|err| err.into())
+                    .and_then(|contents| contents.parse()),
+            ),
+            Self::None {} => None,
+        }
+    }
 }
 
 fn load_jwt_signing_config_from_env() -> JWTSigningConfig {
@@ -564,6 +648,22 @@ fn default_default_retention_period() -> Duration {
 
 fn default_max_nar_info_size() -> usize {
     1024 * 1024 // 1 MiB
+}
+
+fn default_cache_retention_period() -> Option<Duration> {
+    None
+}
+
+fn default_cache_visibility() -> bool {
+    false
+}
+
+fn default_cache_priority() -> i32 {
+    41
+}
+
+fn default_cache_upstream_cache_key_names() -> Vec<String> {
+    vec!["cache.nixos.org-1".to_string()]
 }
 
 fn load_config_from_path(path: &Path) -> Result<Config> {

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -48,6 +48,9 @@ pub enum ErrorKind {
     /// The cache already exists.
     CacheAlreadyExists,
 
+    /// Caches can only be managed via config file
+    DeclarativeCaches,
+
     /// The requested object does not exist.
     NoSuchObject,
 
@@ -176,6 +179,7 @@ impl ErrorKind {
             Self::NoSuchObject => "NoSuchObject",
             Self::NoSuchCache => "NoSuchCache",
             Self::CacheAlreadyExists => "CacheAlreadyExists",
+            Self::DeclarativeCaches => "DeclarativeCaches",
             Self::InvalidCompressionType { .. } => "InvalidCompressionType",
             Self::IncompleteNar => "IncompleteNar",
             Self::AtticError(e) => e.name(),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -26,19 +26,23 @@ pub mod nix_manifest;
 pub mod oobe;
 mod storage;
 
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
+use attic::signing::NixKeypair;
 use axum::{
     Router,
     extract::Extension,
     http::{Uri, uri::Scheme},
 };
+use chrono::Utc;
 use sea_orm::{
-    ConnectionTrait, Database, DatabaseConnection, DatabaseConnectionType, query::Statement,
+    ConnectionTrait, Database, DatabaseConnection, DatabaseConnectionType, EntityTrait,
+    IntoActiveModel, Set, query::Statement,
 };
 use tokio::net::TcpListener;
 use tokio::sync::OnceCell;
@@ -54,6 +58,9 @@ use database::migration::{Migrator, MigratorTrait};
 use error::{ErrorKind, ServerError, ServerResult};
 use middleware::{init_request_state, restrict_host, set_visibility_header};
 use storage::{LocalBackend, S3Backend, StorageBackendImpl};
+
+use crate::database::entity::Json as DbJson;
+use crate::database::entity::cache::{self, Entity as Cache};
 
 type State = Arc<StateInner>;
 type RequestState = Arc<RequestStateInner>;
@@ -283,5 +290,81 @@ pub async fn run_migrations(config: Config) -> Result<()> {
     let db = state.database().await?;
     Migrator::up(db, None).await?;
 
+    eprintln!("Aligning caches with config...");
+
+    let db_caches = Cache::find().all(db).await?;
+    let mut exists = HashSet::new();
+    for cache in db_caches {
+        if let Some(configured) = state.config.caches.get(&cache.name) {
+            exists.insert(cache.name.clone());
+            let mut update = cache.clone().into_active_model();
+            let mut modified = false;
+            if configured.public != cache.is_public {
+                update.is_public = Set(configured.public);
+                modified = true;
+            }
+            let retention = configured
+                .retention_period
+                .map(|duration| duration.as_secs() as i32);
+            if retention != cache.retention_period {
+                update.retention_period = Set(retention);
+                modified = true;
+            }
+            if configured.priority != cache.priority {
+                update.priority = Set(configured.priority);
+                modified = true;
+            }
+            if configured.upstream_cache_key_names != cache.upstream_cache_key_names.0 {
+                update.upstream_cache_key_names =
+                    Set(DbJson(configured.upstream_cache_key_names.clone()));
+                modified = true;
+            }
+            if let Some(new) = configured.keypair.get_keypair() {
+                let keypair = new?.export_keypair();
+                if keypair != cache.keypair {
+                    update.keypair = Set(keypair);
+                    modified = true;
+                }
+            }
+            if modified {
+                eprintln!("Updating cache {:#?}...", cache.name);
+                Cache::update(update).exec(db).await?;
+            }
+        } else if state.config.declarative {
+            eprintln!("Removing cache {:#?}...", cache.name);
+            Cache::delete_by_id(cache.id).exec(db).await?;
+        }
+    }
+
+    if exists.len() == state.config.caches.len() {
+        return Ok(());
+    }
+
+    for (name, config) in state
+        .config
+        .caches
+        .iter()
+        .filter(|(name, _)| !exists.contains(name.as_str()))
+    {
+        eprintln!("Creating cache {:#?}...", name);
+        let keypair = config.keypair.get_keypair().unwrap_or_else(|| {
+            eprintln!("Generating keypair: {:#?}...", name);
+            NixKeypair::generate(name.as_str())
+        })?;
+        let retention = config.retention_period.map(|dur| dur.as_secs() as i32);
+        Cache::insert(cache::ActiveModel {
+            name: Set(name.to_string()),
+            keypair: Set(keypair.export_keypair()),
+            is_public: Set(config.public),
+            store_dir: Set("/nix/store".to_string()),
+            priority: Set(config.priority),
+            retention_period: Set(retention),
+            upstream_cache_key_names: Set(DbJson(config.upstream_cache_key_names.clone())),
+            created_at: Set(Utc::now()),
+            ..Default::default()
+        })
+        .exec(db)
+        .await?;
+    }
     Ok(())
 }


### PR DESCRIPTION
https://github.com/zhaofengli/attic/issues/169

Introduces two config values:
- `caches` contains the same options as configuring caches via API,
however configuring them via config will update the cache any time
migrations are run. If between migrations some setting is changed
manually, it will return to what is inside the config file on the next
migration.
- `declarative` will additionally make sure that any caches that are not
present in the config file will be deleted, so that the config should
represent the source of truth for the cache configuration.

Also disables API cache config operations with declarative caches enabled