### PR TITLE
Updating tutorial instructions for running demo

### DIFF
--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -3,7 +3,7 @@
 Let's spin up Attic in just 15 minutes (yes, it works on macOS too!):
 
 ```bash
-nix-shell https://github.com/zhaofengli/attic/tarball/main -A demo
+$ nix shell github:zhaofengli/attic
 ```
 
 Simply run `atticd` to start the server in monolithic mode with a SQLite database and local storage:
@@ -31,6 +31,8 @@ Enjoy!
 -----------------
 
 Running migrations...
+* Migrating NARs to chunks...
+* Migrating NAR schema...
 Starting API server...
 Listening on [::]:8080...
 ```


### PR DESCRIPTION
`nix-shell https://github.com/zhaofengli/attic/tarball/main -A demo` is outdated and fails with:
```
error: attribute 'demo' in selection path 'demo' not found
```

This PR updates the tutorial instructions to instead use `nix shell github:zhaofengli/attic` which helps locate `attic` and `atticd`:
```
$ nix shell github:zhaofengli/attic
$ which attic   
/nix/store/34hyvbzg5gv0jwl8vajsr16m4f3dy6l4-attic-0.1.0/bin/attic
which atticd
/nix/store/34hyvbzg5gv0jwl8vajsr16m4f3dy6l4-attic-0.1.0/bin/atticd
```