### PR TITLE
fix(docker): retain only one binary in the docker image

### DIFF
--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -111,7 +111,7 @@ in
               pkgs.dockerTools.fakeNss
             ];
             config = {
-              Entrypoint = [ "${self'.packages.attic-server}/bin/atticd" ];
+              Entrypoint = [ "/bin/atticd" ];
               Env = [
                 "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
               ];


### PR DESCRIPTION
This PR fixes #272 . Since we have already copied binaries to the root in:
https://github.com/zhaofengli/attic/blob/687dd7d607824edf11bf33e3d91038467e7fad43/flake/packages.nix#L104-L112
using `${self'.packages.attic-server}/bin/atticd` in the entrypoint will trigger another unnecessary copy.