### PR TITLE
docs: usage instructions for binary cache with NixOS (declaratively)

### DIFF
--- a/book/src/user-guide/README.md
+++ b/book/src/user-guide/README.md
@@ -24,6 +24,23 @@ To configure Nix to automatically use cache `foo`:
 attic use foo
 ```
 
+On NixOS you can add the cache declaratively in your `configuration.nix`:
+```
+nix.settings = {
+  substituters = [
+    "BINARY_CACHE_ENDPOINT"
+  ];
+  trusted-public-keys = [
+    "CACHE_PUBLIC_KEY"
+  ];
+};
+```
+
+To view the binary cache endpoint and cache public key for `foo`:
+```
+attic cache info foo
+```
+
 ## Disabling a cache
 
 To configure Nix to no longer use a cache, remove the corresponding entries from the list of `substituters` and `trusted-public-keys` in `~/.config/nix/nix.conf`

--- a/book/src/user-guide/README.md
+++ b/book/src/user-guide/README.md
@@ -24,21 +24,34 @@ To configure Nix to automatically use cache `foo`:
 attic use foo
 ```
 
-On NixOS you can add the cache declaratively in your `configuration.nix`:
-```
-nix.settings = {
-  substituters = [
-    "BINARY_CACHE_ENDPOINT"
-  ];
-  trusted-public-keys = [
-    "CACHE_PUBLIC_KEY"
-  ];
-};
+This adds the binary cache to your `~/.config/nix/nix.conf` and configures the credentials required to access it.
+
+If you wish to configure Nix manually, you can view the binary cache endpoint and the cache public key:
+
+```console
+$ attic cache info foo
+               Public: true
+           Public Key: foo:WcnO6s4aVkB6CKRaPPpKvHLZykWXASV6c+/Ssg8uQEY=
+Binary Cache Endpoint: https://attic.domain.tld/foo
+      Store Directory: /nix/store
+             Priority: 41
+  Upstream Cache Keys: ["cache.nixos.org-1"]
+     Retention Period: Global Default
 ```
 
-To view the binary cache endpoint and cache public key for `foo`:
-```
-attic cache info foo
+On NixOS, you can configure the cache declaratively in your system configuration with the above information:
+
+```nix
+{
+  nix.settings = {
+    substituters = [
+      "https://attic.domain.tld/foo"
+    ];
+    trusted-public-keys = [
+      "foo:WcnO6s4aVkB6CKRaPPpKvHLZykWXASV6c+/Ssg8uQEY="
+    ];
+  };
+}
 ```
 
 ## Disabling a cache


### PR DESCRIPTION
This PR adds a small section that explains how to enable a cache declaratively with NixOS inside the `configuration.nix` which will help NixOS users setting up their first binary cache more easily.

> I've myself spend some time researching how this is possible with attic so I tried to save other people that time.