### PR TITLE
fix: log non-errors to stdout

### DIFF
--- a/client/src/command/cache.rs
+++ b/client/src/command/cache.rs
@@ -189,7 +189,7 @@ async fn create_cache(sub: Create) -> Result<()> {
     };
 
     api.create_cache(cache, request).await?;
-    eprintln!(
+    println!(
         "✨ Created cache \"{}\" on \"{}\"",
         cache.as_str(),
         server_name.as_str()
@@ -239,7 +239,7 @@ async fn configure_cache(sub: Configure) -> Result<()> {
     let api = ApiClient::from_server_config(server.clone())?;
     api.configure_cache(cache, &patch).await?;
 
-    eprintln!(
+    println!(
         "✅ Configured \"{}\" on \"{}\"",
         cache.as_str(),
         server_name.as_str()
@@ -254,12 +254,12 @@ async fn destroy_cache(sub: Destroy) -> Result<()> {
     let (server_name, server, cache) = config.resolve_cache(&sub.cache)?;
 
     if !sub.no_confirm {
-        eprintln!("When you destory a cache:");
-        eprintln!();
-        eprintln!("1. Everyone will lose access.");
-        eprintln!("2. The underlying data won't be deleted immediately.");
-        eprintln!("3. You may not be able to create a cache of the same name.");
-        eprintln!();
+        println!("When you destory a cache:");
+        println!();
+        println!("1. Everyone will lose access.");
+        println!("2. The underlying data won't be deleted immediately.");
+        println!("3. You may not be able to create a cache of the same name.");
+        println!();
 
         let answer: String = Input::new()
             .with_prompt(format!(
@@ -278,7 +278,7 @@ async fn destroy_cache(sub: Destroy) -> Result<()> {
     let api = ApiClient::from_server_config(server.clone())?;
     api.destroy_cache(cache).await?;
 
-    eprintln!("🗑️ The cache was destroyed.");
+    println!("🗑️ The cache was destroyed.");
 
     Ok(())
 }
@@ -291,40 +291,40 @@ async fn show_cache_config(sub: Info) -> Result<()> {
     let cache_config = api.get_cache_config(cache).await?;
 
     if let Some(is_public) = cache_config.is_public {
-        eprintln!("               Public: {}", is_public);
+        println!("               Public: {}", is_public);
     }
 
     if let Some(public_key) = cache_config.public_key {
-        eprintln!("           Public Key: {}", public_key);
+        println!("           Public Key: {}", public_key);
     }
 
     if let Some(substituter_endpoint) = cache_config.substituter_endpoint {
-        eprintln!("Binary Cache Endpoint: {}", substituter_endpoint);
+        println!("Binary Cache Endpoint: {}", substituter_endpoint);
     }
 
     if let Some(api_endpoint) = cache_config.api_endpoint {
-        eprintln!("         API Endpoint: {}", api_endpoint);
+        println!("         API Endpoint: {}", api_endpoint);
     }
 
     if let Some(store_dir) = cache_config.store_dir {
-        eprintln!("      Store Directory: {}", store_dir);
+        println!("      Store Directory: {}", store_dir);
     }
 
     if let Some(priority) = cache_config.priority {
-        eprintln!("             Priority: {}", priority);
+        println!("             Priority: {}", priority);
     }
 
     if let Some(upstream_cache_key_names) = cache_config.upstream_cache_key_names {
-        eprintln!("  Upstream Cache Keys: {:?}", upstream_cache_key_names);
+        println!("  Upstream Cache Keys: {:?}", upstream_cache_key_names);
     }
 
     if let Some(retention_period) = cache_config.retention_period {
         match retention_period {
             RetentionPeriodConfig::Period(period) => {
-                eprintln!("     Retention Period: {:?}", period);
+                println!("     Retention Period: {:?}", period);
             }
             RetentionPeriodConfig::Global => {
-                eprintln!("     Retention Period: Global Default");
+                println!("     Retention Period: Global Default");
             }
         }
     }

--- a/client/src/command/login.rs
+++ b/client/src/command/login.rs
@@ -28,7 +28,7 @@ pub async fn run(opts: Opts) -> Result<()> {
     let mut config_m = config.as_mut();
 
     if let Some(server) = config_m.servers.get_mut(&sub.name) {
-        eprintln!("✍️ Overwriting server \"{}\"", sub.name.as_str());
+        println!("✍️ Overwriting server \"{}\"", sub.name.as_str());
 
         server.endpoint = sub.endpoint.to_owned();
 
@@ -38,7 +38,7 @@ pub async fn run(opts: Opts) -> Result<()> {
             });
         }
     } else {
-        eprintln!("✍️ Configuring server \"{}\"", sub.name.as_str());
+        println!("✍️ Configuring server \"{}\"", sub.name.as_str());
 
         config_m.servers.insert(
             sub.name.to_owned(),

--- a/client/src/command/push.rs
+++ b/client/src/command/push.rs
@@ -91,7 +91,7 @@ impl PushContext {
 
             return Ok(());
         } else {
-            eprintln!("⚙️ Pushing {num_missing_paths} paths to \"{cache}\" on \"{server}\" ({num_already_cached} already cached, {num_upstream} in upstream)...",
+            println!("⚙️ Pushing {num_missing_paths} paths to \"{cache}\" on \"{server}\" ({num_already_cached} already cached, {num_upstream} in upstream)...",
                 cache = self.cache_name.as_str(),
                 server = self.server_name.as_str(),
                 num_missing_paths = plan.store_path_map.len(),

--- a/client/src/command/use.rs
+++ b/client/src/command/use.rs
@@ -34,15 +34,15 @@ pub async fn run(opts: Opts) -> Result<()> {
     let public_key = cache_config.public_key
         .ok_or_else(|| anyhow!("The server did not tell us which public key it uses. Is signing managed by the client?"))?;
 
-    eprintln!(
+    println!(
         "Configuring Nix to use \"{cache}\" on \"{server_name}\":",
         cache = cache.as_str(),
         server_name = server_name.as_str(),
     );
 
     // Modify nix.conf
-    eprintln!("+ Substituter: {}", substituter);
-    eprintln!("+ Trusted Public Key: {}", public_key);
+    println!("+ Substituter: {}", substituter);
+    println!("+ Trusted Public Key: {}", public_key);
 
     let mut nix_config = NixConfig::load().await?;
     nix_config.add_substituter(&substituter);
@@ -50,7 +50,7 @@ pub async fn run(opts: Opts) -> Result<()> {
 
     // Modify netrc
     if let Some(token) = server.token()? {
-        eprintln!("+ Access Token");
+        println!("+ Access Token");
 
         let mut nix_netrc = NixNetrc::load().await?;
         let host = Url::parse(&substituter)?

--- a/client/src/command/watch_store.rs
+++ b/client/src/command/watch_store.rs
@@ -91,7 +91,7 @@ pub async fn run(opts: Opts) -> Result<()> {
 
     watcher.watch(&store_dir, RecursiveMode::NonRecursive)?;
 
-    eprintln!(
+    println!(
         "👀 Pushing new store paths to \"{cache}\" on \"{server}\"",
         cache = cache.as_str(),
         server = server_name.as_str(),

--- a/client/src/push.rs
+++ b/client/src/push.rs
@@ -595,7 +595,7 @@ pub async fn upload_path(
             };
 
             mp.suspend(|| {
-                eprintln!(
+                println!(
                     "✅ {} ({})",
                     path.as_os_str().to_string_lossy(),
                     info_string

--- a/server/src/database/migration/m20230112_000004_migrate_nar_remote_files_to_chunks.rs
+++ b/server/src/database/migration/m20230112_000004_migrate_nar_remote_files_to_chunks.rs
@@ -24,7 +24,7 @@ impl MigrationTrait for Migration {
         // When this migration is run, we assume that there are no
         // preexisting chunks.
 
-        eprintln!("* Migrating NARs to chunks...");
+        println!("* Migrating NARs to chunks...");
 
         // Add a temporary column into `chunk` to store the related `nar_id`.
         manager

--- a/server/src/database/migration/m20230112_000005_drop_old_nar_columns.rs
+++ b/server/src/database/migration/m20230112_000005_drop_old_nar_columns.rs
@@ -16,7 +16,7 @@ impl MigrationName for Migration {
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        eprintln!("* Migrating NAR schema...");
+        println!("* Migrating NAR schema...");
 
         if manager.get_database_backend() == DatabaseBackend::Sqlite {
             // Just copy all data to a new table

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -217,7 +217,7 @@ async fn fallback(_: Uri) -> ServerResult<()> {
 
 /// Runs the API server.
 pub async fn run_api_server(cli_listen: Option<SocketAddr>, config: Config) -> Result<()> {
-    eprintln!("Starting API server...");
+    println!("Starting API server...");
 
     let state = StateInner::new(config).await;
 
@@ -239,7 +239,7 @@ pub async fn run_api_server(cli_listen: Option<SocketAddr>, config: Config) -> R
         .layer(TraceLayer::new_for_http())
         .layer(CatchPanicLayer::new());
 
-    eprintln!("Listening on {:?}...", listen);
+    println!("Listening on {:?}...", listen);
 
     let listener = TcpListener::bind(&listen).await?;
 
@@ -256,7 +256,7 @@ pub async fn run_api_server(cli_listen: Option<SocketAddr>, config: Config) -> R
 
 /// Runs database migrations.
 pub async fn run_migrations(config: Config) -> Result<()> {
-    eprintln!("Running migrations...");
+    println!("Running migrations...");
 
     let state = StateInner::new(config).await;
     let db = state.database().await?;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -121,14 +121,14 @@ fn init_logging(tokio_console: bool) {
         .init();
 
     if tokio_console {
-        eprintln!("Note: tokio-console is enabled");
+        println!("Note: tokio-console is enabled");
     }
 }
 
 fn dump_version() {
     #[cfg(debug_assertions)]
-    eprintln!("Attic Server {} (debug)", env!("CARGO_PKG_VERSION"));
+    println!("Attic Server {} (debug)", env!("CARGO_PKG_VERSION"));
 
     #[cfg(not(debug_assertions))]
-    eprintln!("Attic Server {} (release)", env!("CARGO_PKG_VERSION"));
+    println!("Attic Server {} (release)", env!("CARGO_PKG_VERSION"));
 }

--- a/server/src/oobe.rs
+++ b/server/src/oobe.rs
@@ -77,25 +77,25 @@ pub async fn run_oobe() -> Result<()> {
         token.encode(&SignatureType::RS256(key), &None, &None)?
     };
 
-    eprintln!();
-    eprintln!("-----------------");
-    eprintln!("Welcome to Attic!");
-    eprintln!();
-    eprintln!("A simple setup using SQLite and local storage has been configured for you in:");
-    eprintln!();
-    eprintln!("    {}", config_path.to_str().unwrap());
-    eprintln!();
-    eprintln!("Run the following command to log into this server:");
-    eprintln!();
-    eprintln!("    attic login local http://localhost:8080 {root_token}");
-    eprintln!();
-    eprintln!("Documentations and guides:");
-    eprintln!();
-    eprintln!("    https://docs.attic.rs");
-    eprintln!();
-    eprintln!("Enjoy!");
-    eprintln!("-----------------");
-    eprintln!();
+    println!();
+    println!("-----------------");
+    println!("Welcome to Attic!");
+    println!();
+    println!("A simple setup using SQLite and local storage has been configured for you in:");
+    println!();
+    println!("    {}", config_path.to_str().unwrap());
+    println!();
+    println!("Run the following command to log into this server:");
+    println!();
+    println!("    attic login local http://localhost:8080 {root_token}");
+    println!();
+    println!("Documentations and guides:");
+    println!();
+    println!("    https://docs.attic.rs");
+    println!();
+    println!("Enjoy!");
+    println!("-----------------");
+    println!();
 
     Ok(())
 }


### PR DESCRIPTION
Currently, many normal operational messages (cache creation/configuration, migrations, welcome messages, etc.) are logged to `stderr`, which is intended for errors and warnings. Logging non-errors to `stderr` pollutes system logs (e.g., `journalctl`) and can mislead users or automation tooling that rely on `stderr` to indicate actual failures.

This PR changes non-error messages from `stderr` to `stdout` across both client and server commands. 