### PR TITLE
attic-client: Allow stateless login

### DIFF
--- a/book/src/user-guide/README.md
+++ b/book/src/user-guide/README.md
@@ -16,6 +16,26 @@ To select the `foo` cache from server `central`, use one of the following:
 
 To configure the default server, set `default-server` in `~/.config/attic/config.toml`.
 
+## Stateless Login
+
+`attic login` modifies local state. In cases where you don’t want to persist state--such as CI--you can use environment variables instead.
+
+Supported ENVs:
+
+- `ATTIC_LOGIN_ENDPOINT`: Server URL. When set, requires `ATTIC_LOGIN_NAME`.
+- `ATTIC_LOGIN_NAME`: Name for the `ATTIC_LOGIN_ENDPOINT`.
+- `ATTIC_LOGIN_TOKEN` or `ATTIC_LOGIN_TOKEN_FILE`: Inline token value or path to a file containing the token. When both are set, `ATTIC_LOGIN_TOKEN_FILE` takes precedence.
+- `ATTIC_LOGIN_FORCE_DEFAULT`: If set to any value, forces the server specified by `ATTIC_LOGIN_NAME` to be the default server.
+
+Example:
+
+```bash
+ATTIC_LOGIN_NAME=test \
+ATTIC_LOGIN_ENDPOINT=https://attic.example.com \
+ATTIC_LOGIN_TOKEN=eyJ... \
+attic push test:foo paths
+```
+
 ## Enabling a cache
 
 To configure Nix to automatically use cache `foo`:

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -3,13 +3,16 @@
 //! Configuration files are stored under `$XDG_CONFIG_HOME/attic/config.toml`.
 //! We automatically write modified configurations back for a good end-user
 //! experience (e.g., `attic login`).
-
+//!
+//! Stateless configuration through environment variables is also supported (see below).
 use std::collections::HashMap;
+use std::env;
 use std::fs::{self, read_to_string, OpenOptions, Permissions};
 use std::io::Write;
 use std::ops::{Deref, DerefMut};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -25,11 +28,40 @@ const XDG_PREFIX: &str = "attic";
 /// The permission the configuration file should have.
 const FILE_MODE: u32 = 0o600;
 
-/// Configuration loader.
-#[derive(Debug)]
+/// Supported Environment Variables for stateless configuration:
+const ATTIC_LOGIN_ENDPOINT: &str = "ATTIC_LOGIN_ENDPOINT"; // Server URL. When set, requires `ATTIC_LOGIN_NAME`.
+const ATTIC_LOGIN_NAME: &str = "ATTIC_LOGIN_NAME"; // Name for the `ATTIC_LOGIN_ENDPOINT`.
+const ATTIC_LOGIN_FORCE_DEFAULT: &str = "ATTIC_LOGIN_FORCE_DEFAULT"; // If set to any value, forces the server specified by `ATTIC_LOGIN_NAME` to be the default server.
+const ATTIC_LOGIN_TOKEN: &str = "ATTIC_LOGIN_TOKEN"; // Inline token value.
+const ATTIC_LOGIN_TOKEN_FILE: &str = "ATTIC_LOGIN_TOKEN_FILE"; // Path to a file containing the token.
+
+/// Configuration loader from all sources.
 pub struct Config {
+    /// Configuration from TOML file persisted on disk.
+    toml: TomlConfig,
+
+    /// Configuration from environment variables.
+    env: Option<EnvConfig>,
+}
+
+/// Configuration loader from environment variables.
+///
+/// During resolution, this takes precedence over `TomlConfig`.
+struct EnvConfig {
+    /// The server name specified by `ATTIC_LOGIN_NAME` env.
+    login_server_name: ServerName,
+
+    /// The configuration used to connect to the server specified by `ATTIC_LOGIN_ENDPOINT` env.
+    login_server_config: ServerConfig,
+
+    /// Whether to force the server specified by `ATTIC_LOGIN_NAME` to be the default server.
+    login_force_default: bool,
+}
+/// Toml Configuration loader.
+#[derive(Debug)]
+struct TomlConfig {
     /// Actual configuration data.
-    data: ConfigData,
+    data: TomlConfigData,
 
     /// Path to write modified configurations back to.
     path: Option<PathBuf>,
@@ -37,7 +69,7 @@ pub struct Config {
 
 /// Client configurations.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
-pub struct ConfigData {
+pub struct TomlConfigData {
     /// The default server to connect to.
     #[serde(rename = "default-server")]
     pub default_server: Option<ServerName>,
@@ -56,7 +88,36 @@ pub struct ServerConfig {
     pub token: Option<ServerTokenConfig>,
 }
 
+/// Copied from server/src/config.rs
+fn read_non_empty_var(key: &str) -> Result<Option<String>> {
+    let value = match env::var(key) {
+        Err(env::VarError::NotPresent) => {
+            return Ok(None);
+        }
+        r => r?,
+    };
+
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(value))
+    }
+}
+
 impl ServerConfig {
+    /// Create a `ServerConfig` from environment variables if `ATTIC_LOGIN_ENDPOINT` is set.
+    pub fn from_env() -> Result<Option<Self>> {
+        let endpoint = match read_non_empty_var(ATTIC_LOGIN_ENDPOINT)
+            .with_context(|| format!("Failed to read {ATTIC_LOGIN_ENDPOINT} env"))?
+        {
+            Some(endpoint) => endpoint,
+            None => return Ok(None),
+        };
+
+        let token = ServerTokenConfig::from_env()?;
+
+        Ok(Some(ServerConfig { endpoint, token }))
+    }
     pub fn token(&self) -> Result<Option<String>> {
         self.token.as_ref().map(|token| token.get()).transpose()
     }
@@ -76,6 +137,25 @@ pub enum ServerTokenConfig {
 }
 
 impl ServerTokenConfig {
+    /// Create a `ServerTokenConfig` from environment variables
+    ///
+    /// If both `ATTIC_LOGIN_TOKEN` and `ATTIC_LOGIN_TOKEN_FILE` env vars are set, the latter takes precedence.
+    pub fn from_env() -> Result<Option<Self>> {
+        if let Some(token_file) = read_non_empty_var(ATTIC_LOGIN_TOKEN_FILE)
+            .with_context(|| format!("Failed to read {ATTIC_LOGIN_TOKEN_FILE} env"))?
+        {
+            return Ok(Some(ServerTokenConfig::File { token_file }));
+        }
+
+        if let Some(token) = read_non_empty_var(ATTIC_LOGIN_TOKEN)
+            .with_context(|| format!("Failed to read {ATTIC_LOGIN_TOKEN} env"))?
+        {
+            return Ok(Some(ServerTokenConfig::Raw { token }));
+        }
+
+        Ok(None)
+    }
+
     /// Get the token either directly from the config or through the token file
     pub fn get(&self) -> Result<String> {
         match self {
@@ -88,9 +168,112 @@ impl ServerTokenConfig {
 }
 
 /// Wrapper that automatically saves the config once dropped.
-pub struct ConfigWriteGuard<'a>(&'a mut Config);
+pub struct TomlConfigWriteGuard<'a>(&'a mut TomlConfig);
 
 impl Config {
+    pub fn load() -> Result<Self> {
+        Ok(Self {
+            toml: TomlConfig::load()?,
+            env: EnvConfig::load()?,
+        })
+    }
+
+    /// Get the server configuration by server name.
+    ///
+    /// If `EnvConfig` is set and `login_server_name` matches the requested server name, it takes precedence over `TomlConfig`.
+    pub fn get_server<'b>(
+        &'b self,
+        name: &'b ServerName,
+    ) -> Result<(&'b ServerName, &'b ServerConfig)> {
+        if let Some(env) = &self.env {
+            if name == &env.login_server_name {
+                return Ok((&env.login_server_name, &env.login_server_config));
+            } else {
+                tracing::warn!(
+                    "ATTIC_LOGIN_* environment is set for server '{}' but request targets server '{}'; using TOML configuration.",
+                    env.login_server_name.as_str(),
+                    name.as_str(),
+                );
+            }
+        }
+        let cfg = self
+            .toml
+            .data
+            .servers
+            .get(name)
+            .ok_or_else(|| anyhow!("Server \"{}\" does not exist", name.as_str()))?;
+        Ok((name, cfg))
+    }
+
+    /// Get the default server configuration.
+    ///
+    /// If `EnvConfig` is set and `login_force_default` is true, it takes precedence over `TomlConfig`.
+    pub fn default_server(&self) -> Result<(&ServerName, &ServerConfig)> {
+        if let Some(env) = &self.env {
+            if env.login_force_default {
+                return Ok((&env.login_server_name, &env.login_server_config));
+            } else {
+                tracing::warn!(
+                    "Ignoring ATTIC_LOGIN_* environment as '{}' server is not default. Make it default by setting {ATTIC_LOGIN_FORCE_DEFAULT}=1",
+                    env.login_server_name.as_str(),
+                );
+            }
+        }
+        self.toml.data.default_server()
+    }
+
+    pub fn resolve_cache<'b>(
+        &'b self,
+        r: &'b CacheRef,
+    ) -> Result<(&'b ServerName, &'b ServerConfig, &'b CacheName)> {
+        match r {
+            CacheRef::DefaultServer(cache) => {
+                let (name, config) = self.default_server()?;
+                Ok((name, config, cache))
+            }
+            CacheRef::ServerQualified(server, cache) => {
+                let (name, config) = self.get_server(server)?;
+                Ok((name, config, cache))
+            }
+        }
+    }
+
+    // Forward a write guard for toml config persistence
+    pub fn as_mut(&mut self) -> TomlConfigWriteGuard<'_> {
+        self.toml.as_mut()
+    }
+}
+
+impl EnvConfig {
+    fn load() -> Result<Option<Self>> {
+        let login_server_config = match ServerConfig::from_env()? {
+            Some(cfg) => cfg,
+            None => return Ok(None),
+        };
+
+        let login_server_name = match read_non_empty_var(ATTIC_LOGIN_NAME)
+            .with_context(|| format!("Failed to read {ATTIC_LOGIN_NAME} env"))?
+        {
+            Some(name) => ServerName::from_str(&name)?,
+            None => {
+                return Err(anyhow!(
+                "{ATTIC_LOGIN_NAME}=<name> env must be set when {ATTIC_LOGIN_ENDPOINT} is provided"
+            ))
+            }
+        };
+
+        let login_force_default = read_non_empty_var(ATTIC_LOGIN_FORCE_DEFAULT)
+            .with_context(|| format!("Failed to read {ATTIC_LOGIN_FORCE_DEFAULT} env"))?
+            .is_some();
+
+        Ok(Some(Self {
+            login_server_name,
+            login_server_config,
+            login_force_default,
+        }))
+    }
+}
+impl TomlConfig {
     /// Loads the configuration from the system.
     pub fn load() -> Result<Self> {
         let path = get_config_path()
@@ -100,14 +283,14 @@ impl Config {
             })
             .ok();
 
-        let data = ConfigData::load_from_path(path.as_ref())?;
+        let data = TomlConfigData::load_from_path(path.as_ref())?;
 
         Ok(Self { data, path })
     }
 
     /// Returns a mutable reference to the configuration.
-    pub fn as_mut(&mut self) -> ConfigWriteGuard {
-        ConfigWriteGuard(self)
+    pub fn as_mut(&mut self) -> TomlConfigWriteGuard {
+        TomlConfigWriteGuard(self)
     }
 
     /// Saves the configuration back to the system, if possible.
@@ -138,15 +321,15 @@ impl Config {
     }
 }
 
-impl Deref for Config {
-    type Target = ConfigData;
+impl Deref for TomlConfig {
+    type Target = TomlConfigData;
 
     fn deref(&self) -> &Self::Target {
         &self.data
     }
 }
 
-impl ConfigData {
+impl TomlConfigData {
     fn load_from_path(path: Option<&PathBuf>) -> Result<Self> {
         if let Some(path) = path {
             if path.exists() {
@@ -157,7 +340,7 @@ impl ConfigData {
             }
         }
 
-        Ok(ConfigData::default())
+        Ok(TomlConfigData::default())
     }
 
     pub fn default_server(&self) -> Result<(&ServerName, &ServerConfig)> {
@@ -175,42 +358,23 @@ impl ConfigData {
             Err(anyhow!("No servers are available."))
         }
     }
-
-    pub fn resolve_cache<'a>(
-        &'a self,
-        r: &'a CacheRef,
-    ) -> Result<(&'a ServerName, &'a ServerConfig, &'a CacheName)> {
-        match r {
-            CacheRef::DefaultServer(cache) => {
-                let (name, config) = self.default_server()?;
-                Ok((name, config, cache))
-            }
-            CacheRef::ServerQualified(server, cache) => {
-                let config = self
-                    .servers
-                    .get(server)
-                    .ok_or_else(|| anyhow!("Server \"{}\" does not exist", server.as_str()))?;
-                Ok((server, config, cache))
-            }
-        }
-    }
 }
 
-impl<'a> Deref for ConfigWriteGuard<'a> {
-    type Target = ConfigData;
+impl<'a> Deref for TomlConfigWriteGuard<'a> {
+    type Target = TomlConfigData;
 
     fn deref(&self) -> &Self::Target {
         &self.0.data
     }
 }
 
-impl<'a> DerefMut for ConfigWriteGuard<'a> {
+impl<'a> DerefMut for TomlConfigWriteGuard<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0.data
     }
 }
 
-impl<'a> Drop for ConfigWriteGuard<'a> {
+impl<'a> Drop for TomlConfigWriteGuard<'a> {
     fn drop(&mut self) {
         if let Err(e) = self.0.save() {
             tracing::error!("Could not save modified configuration: {}", e);

--- a/integration-tests/basic/default.nix
+++ b/integration-tests/basic/default.nix
@@ -273,6 +273,11 @@ in {
           client.fail("attic cache info test")
           client.fail("curl -sL --fail-with-body http://server:8080/test/nix-cache-info")
 
+      with subtest("Basic stateless auth check"):
+          access_envs = f"ATTIC_LOGIN_ENDPOINT=http://server:8080 ATTIC_LOGIN_NAME=env ATTIC_LOGIN_TOKEN={root_token}"
+          client.succeed(f"{access_envs} attic cache create env:test")
+          client.succeed(f"{access_envs} attic cache destroy --no-confirm env:test")
+
       ${databaseModules.${config.database}.testScriptPost or ""}
       ${storageModules.${config.storage}.testScriptPost or ""}
     '';


### PR DESCRIPTION
resolves #243 

by reading/supporting the following client-side environment variables:
- `ATTIC_LOGIN_ENDPOINT`: Server URL. When set, requires `ATTIC_LOGIN_NAME`.
- `ATTIC_LOGIN_NAME`: Name for the `ATTIC_LOGIN_ENDPOINT`.
- `ATTIC_LOGIN_TOKEN` or `ATTIC_LOGIN_TOKEN_FILE`: Inline token value or path to a file containing the token. When both are set, `ATTIC_LOGIN_TOKEN_FILE` takes precedence.
- `ATTIC_LOGIN_FORCE_DEFAULT`: If set to any value, forces the server specified by `ATTIC_LOGIN_NAME` to be the default server.


Basic usage example:
```bash
ATTIC_LOGIN_NAME=test \
ATTIC_LOGIN_ENDPOINT=https://attic.example.com \
ATTIC_LOGIN_TOKEN=eyJ... \
attic push test:foo paths
```

I considered supporting a smaller set of environment variables (everything except `ATTIC_LOGIN_NAME` and `ATTIC_LOGIN_FORCE_DEFAULT`), but that would change the client behaviour by doing things that the user might not have asked for (Like enforcing the server from env when the `CacheRef` [`<server>:<cache>`] expects a different server). Hence, chose to keep the two extra env vars to maintain behavioural correctness.


### A note on precedence

Login configuration via env, if set, is given precedence over persisted toml config if the requested server name (a user can request from client using `<server>:<cache>` ref) matches the server name in `ATTIC_LOGIN_NAME`.If the user does not specify a server name, the toml configuration’s `default-server` is used -- unless `ATTIC_LOGIN_FORCE_DEFAULT` is set, in which case the env config takes precedence.
