### PR TITLE
server/config: Add JWT subject blacklist for revoking tokens

### DIFF
--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -115,6 +115,19 @@ eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbGljZSIsImV4cCI6MTY4MDI5MzQyNSw
 Now Alice can use this token to _create_ any cache beginning with `alice-` and push to them.
 Try passing `--dump-claims` to show the JWT claims without encoding the token to see what's going on.
 
+## Token Revocation
+
+Sometimes you need to revoke access for specific users without regenerating all tokens.
+Attic supports blacklisting JWT subjects through server configuration:
+
+```toml
+# In server.toml
+[jwt.blacklist]
+subjects = ["alice"]
+```
+
+After adding subjects to the blacklist and restarting the server, any tokens with those subjects will be rejected.
+
 ## Going Public
 
 Let's make the cache public. Making it public gives unauthenticated users pull access:

--- a/integration-tests/basic/default.nix
+++ b/integration-tests/basic/default.nix
@@ -156,7 +156,7 @@ in {
           settings = {
             listen = "[::]:8080";
 
-            jwt = { };
+            jwt.blacklist.subjects = [ "alice" ];
 
             chunking = {
               nar-size-threshold = 1;
@@ -190,10 +190,12 @@ in {
 
       root_token = server.succeed("${cmd.atticadm} make-token --sub 'e2e-root' --validity '1 month' --push '*' --pull '*' --delete '*' --create-cache '*' --destroy-cache '*' --configure-cache '*' --configure-cache-retention '*' </dev/null").strip()
       readonly_token = server.succeed("${cmd.atticadm} make-token --sub 'e2e-root' --validity '1 month' --pull 'test' </dev/null").strip()
+      blacklisted_token = server.succeed("${cmd.atticadm} make-token --sub 'alice' --validity '1 month' --push '*' --pull '*' --create-cache '*' </dev/null").strip()
 
       client.succeed(f"attic login --set-default root http://server:8080 {root_token}")
       client.succeed(f"attic login readonly http://server:8080 {readonly_token}")
       client.succeed("attic login anon http://server:8080")
+      client.succeed(f"attic login blacklisted http://server:8080 {blacklisted_token}")
 
       # TODO: Make sure the correct status codes are returned
       # (i.e., 500s shouldn't pass the "should fail" tests)
@@ -272,6 +274,11 @@ in {
           client.succeed("attic cache destroy --no-confirm test")
           client.fail("attic cache info test")
           client.fail("curl -sL --fail-with-body http://server:8080/test/nix-cache-info")
+
+      with subtest("Check that token with blacklisted subject is rejected"):
+          client.fail("attic cache create blacklisted:test-blacklist")
+          client.fail(f"attic push blacklisted:test {test_file}")
+          client.fail("attic use blacklisted:test")
 
       ${databaseModules.${config.database}.testScriptPost or ""}
       ${storageModules.${config.storage}.testScriptPost or ""}

--- a/server/src/access/http.rs
+++ b/server/src/access/http.rs
@@ -112,9 +112,22 @@ pub async fn apply_auth(req: Request, next: Next) -> Response {
 
             if let Err(e) = &res_token {
                 tracing::debug!("Ignoring bad JWT token: {}", e);
+                return None;
             }
 
-            res_token.ok()
+            let token = res_token.ok()?;
+
+            // Check if subject of the token is blacklisted
+            if let Some(blacklist) = &state.config.jwt.blacklist {
+                if let Some(subject) = token.sub() {
+                    if blacklist.subjects.contains(subject) {
+                        tracing::warn!("Rejecting token with blacklisted subject: {}", subject);
+                        return None;
+                    }
+                }
+            }
+
+            Some(token)
         });
 
     if let Some(token) = token {

--- a/server/src/config-template.toml
+++ b/server/src/config-template.toml
@@ -150,6 +150,15 @@ interval = "12 hours"
 # contains at least one of these values.
 #token-bound-audiences = ["some-audience1", "some-audience2"]
 
+# JWT token blacklist
+[jwt.blacklist]
+# Blacklisted JWT subjects
+#
+# List of JWT `sub` claims that should be rejected.
+# Tokens with these subjects will be denied access regardless
+# of signature validity.
+#subjects = ["alice", "bob"]
+
 [jwt.signing]
 # JWT RS256 secret key
 #

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -159,11 +159,30 @@ pub struct JWTConfig {
     #[serde(default = "Default::default")]
     pub token_bound_audiences: Option<HashSet<String>>,
 
+    /// JWT token blacklist configuration.
+    #[serde(default)]
+    pub blacklist: Option<JWTBlacklistConfig>,
+
     /// JSON Web Token signing.
     #[serde(rename = "signing")]
     #[serde(default = "load_jwt_signing_config_from_env")]
     #[debug(skip)]
     pub signing_config: JWTSigningConfig,
+}
+
+/// JWT token blacklist configuration.
+#[derive(Clone, Debug, Deserialize)]
+pub struct JWTBlacklistConfig {
+    /// Blacklisted JWT subjects.
+    ///
+    /// List of JWT `sub` claims that should be rejected.
+    /// Tokens with these subjects will be denied access regardless
+    /// of signature validity.
+    ///
+    /// Note: Configured as TOML array, stored as HashSet for O(1) lookup
+    /// on every authenticated request.
+    #[serde(default)]
+    pub subjects: HashSet<String>,
 }
 
 /// JSON Web Token signing configuration.
@@ -425,6 +444,7 @@ impl Default for JWTConfig {
         Self {
             token_bound_issuer: None,
             token_bound_audiences: None,
+            blacklist: None,
             signing_config: load_jwt_signing_config_from_env(),
         }
     }


### PR DESCRIPTION
Adds `jwt.blacklist.subjects` config option to blacklist JWT tokens by subject claim. Useful for revoking access without regenerating all tokens. Requires server restart to update blacklist.