### PR TITLE
test: fix local `nix flake check` permission error

### DIFF
--- a/integration-tests/basic/default.nix
+++ b/integration-tests/basic/default.nix
@@ -45,10 +45,11 @@ let
       server = {
         services.postgresql = {
           enable = true;
-          ensureDatabases = [ "attic" ];
+          ensureDatabases = [ "atticd" ];
           ensureUsers = [
             {
               name = "atticd";
+              ensureDBOwnership = true;
             }
 
             # For testing only - Don't actually do this
@@ -61,19 +62,15 @@ let
           ];
         };
 
-        systemd.services.postgresql-setup.postStart = lib.mkAfter ''
-          psql -tAc 'ALTER DATABASE "attic" OWNER TO "atticd"'
-        '';
-
         services.atticd.settings = {
-          database.url = "postgresql:///attic?host=/run/postgresql";
+          database.url = "postgresql:///atticd?host=/run/postgresql";
         };
       };
       testScriptPost = ''
         from pathlib import Path
         import os
 
-        schema = server.succeed("pg_dump --schema-only attic")
+        schema = server.succeed("pg_dump --schema-only atticd")
 
         schema_path = Path(os.environ.get("out", os.getcwd())) / "schema.sql"
         with open(schema_path, 'w') as f:


### PR DESCRIPTION
I fixed an issue where running `nix flake check` locally would cause a PostgreSQL permission error.
This was likely caused by PostgreSQL version 15 introducing stricter permission checks.
While I considered adding permissions through an additional script,
I decided that aligning the test environment with real production environments would be more beneficial,
since people in actual operations would probably use `ensureDBOwnership`,
or even without it, would typically use the same name for both username and database name.
Therefore, I changed the database name used in tests.
