### PR TITLE
Update C++ standard in build.rs

### DIFF
--- a/attic/build.rs
+++ b/attic/build.rs
@@ -36,7 +36,7 @@ mod nix_store {
         let mut build = cxx_build::bridge("src/nix_store/bindings/mod.rs");
         build
             .file("src/nix_store/bindings/nix.cpp")
-            .flag("-std=c++2a")
+            .flag("-std=c++23")
             .flag("-O2")
             .includes(deps.all_include_paths());
 


### PR DESCRIPTION
Newer Nix versions require C++23.

This doesn't completely fix the build, but I don't know enough about the Nix internals that are being bound to here to comfortably fix that.