### PR TITLE
feat: use clap to handle env args for logging in

### DIFF
--- a/book/src/user-guide/README.md
+++ b/book/src/user-guide/README.md
@@ -16,6 +16,26 @@ To select the `foo` cache from server `central`, use one of the following:
 
 To configure the default server, set `default-server` in `~/.config/attic/config.toml`.
 
+## Stateless Login
+
+`attic login` modifies local state. In cases where you don’t want to persist state--such as CI--you can use environment variables instead.
+
+Supported ENVs:
+
+- `ATTIC_LOGIN_ENDPOINT`: Server URL. When set, requires `ATTIC_LOGIN_NAME`.
+- `ATTIC_LOGIN_NAME`: Name for the `ATTIC_LOGIN_ENDPOINT`.
+- `ATTIC_LOGIN_TOKEN`: Inline token value.
+- `ATTIC_LOGIN_FORCE_DEFAULT`: If set to any value, forces the server specified by `ATTIC_LOGIN_NAME` to be the default server.
+
+Example:
+
+```bash
+ATTIC_LOGIN_NAME=test \
+ATTIC_LOGIN_ENDPOINT=https://attic.example.com \
+ATTIC_LOGIN_TOKEN=eyJ... \
+attic push test:foo paths
+```
+
 ## Enabling a cache
 
 To configure Nix to automatically use cache `foo`:

--- a/book/src/user-guide/README.md
+++ b/book/src/user-guide/README.md
@@ -16,9 +16,10 @@ To select the `foo` cache from server `central`, use one of the following:
 
 To configure the default server, set `default-server` in `~/.config/attic/config.toml`.
 
-## Stateless Login
+## Environment Variables Login
 
-`attic login` modifies local state. In cases where you don’t want to persist state--such as CI--you can use environment variables instead.
+`attic login` normally takes arguments.
+In cases where you want/need to run commands unattended, such as CI, you can use environment variables instead.
 
 Supported ENVs:
 
@@ -33,6 +34,8 @@ Example:
 ATTIC_LOGIN_NAME=test \
 ATTIC_LOGIN_ENDPOINT=https://attic.example.com \
 ATTIC_LOGIN_TOKEN=eyJ... \
+attic login
+# Now that you have been logged in you can now use any other command.
 attic push test:foo paths
 ```
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,7 +14,7 @@ attic = { path = "../attic" }
 anyhow = "1.0.98"
 async-channel = "2.5.0"
 bytes = "1.10.1"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5.54"
 const_format = "0.2.34"
 dialoguer = "0.11.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,7 +14,7 @@ attic = { path = "../attic" }
 anyhow = "1.0.98"
 async-channel = "2.5.0"
 bytes = "1.10.1"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5.54"
 const_format = "0.2.34"
 dialoguer = "0.12.0"

--- a/client/src/command/login.rs
+++ b/client/src/command/login.rs
@@ -9,16 +9,19 @@ use crate::config::{Config, ServerConfig, ServerTokenConfig};
 #[derive(Debug, Parser)]
 pub struct Login {
     /// Name of the server.
+    #[arg(env = "ATTIC_LOGIN_NAME")]
     name: ServerName,
 
     /// Endpoint of the server.
+    #[arg(env = "ATTIC_LOGIN_ENDPOINT")]
     endpoint: String,
 
     /// Access token.
+    #[arg(env = "ATTIC_LOGIN_TOKEN")]
     token: Option<String>,
 
     /// Set the server as the default.
-    #[clap(long)]
+    #[clap(long, env = "ATTIC_LOGIN_FORCE_DEFAULT")]
     set_default: bool,
 }
 

--- a/integration-tests/basic/default.nix
+++ b/integration-tests/basic/default.nix
@@ -275,6 +275,7 @@ in {
 
       with subtest("Basic stateless auth check"):
           access_envs = f"ATTIC_LOGIN_ENDPOINT=http://server:8080 ATTIC_LOGIN_NAME=env ATTIC_LOGIN_TOKEN={root_token}"
+          client.succeed(f"{access_envs} attic login")
           client.succeed(f"{access_envs} attic cache create env:test")
           client.succeed(f"{access_envs} attic cache destroy --no-confirm env:test")
 

--- a/integration-tests/basic/default.nix
+++ b/integration-tests/basic/default.nix
@@ -273,6 +273,11 @@ in {
           client.fail("attic cache info test")
           client.fail("curl -sL --fail-with-body http://server:8080/test/nix-cache-info")
 
+      with subtest("Basic stateless auth check"):
+          access_envs = f"ATTIC_LOGIN_ENDPOINT=http://server:8080 ATTIC_LOGIN_NAME=env ATTIC_LOGIN_TOKEN={root_token}"
+          client.succeed(f"{access_envs} attic cache create env:test")
+          client.succeed(f"{access_envs} attic cache destroy --no-confirm env:test")
+
       ${databaseModules.${config.database}.testScriptPost or ""}
       ${storageModules.${config.storage}.testScriptPost or ""}
     '';

--- a/integration-tests/basic/default.nix
+++ b/integration-tests/basic/default.nix
@@ -290,6 +290,7 @@ in {
 
       with subtest("Basic stateless auth check"):
           access_envs = f"ATTIC_LOGIN_ENDPOINT=http://server:8080 ATTIC_LOGIN_NAME=env ATTIC_LOGIN_TOKEN={root_token}"
+          client.succeed(f"{access_envs} attic login")
           client.succeed(f"{access_envs} attic cache create env:test")
           client.succeed(f"{access_envs} attic cache destroy --no-confirm env:test")
 

--- a/integration-tests/basic/default.nix
+++ b/integration-tests/basic/default.nix
@@ -288,6 +288,11 @@ in {
           client.fail("attic cache info test")
           client.fail("curl -sL --fail-with-body http://server:8080/test/nix-cache-info")
 
+      with subtest("Basic stateless auth check"):
+          access_envs = f"ATTIC_LOGIN_ENDPOINT=http://server:8080 ATTIC_LOGIN_NAME=env ATTIC_LOGIN_TOKEN={root_token}"
+          client.succeed(f"{access_envs} attic cache create env:test")
+          client.succeed(f"{access_envs} attic cache destroy --no-confirm env:test")
+
       ${databaseModules.${config.database}.testScriptPost or ""}
       ${storageModules.${config.storage}.testScriptPost or ""}
     '';


### PR DESCRIPTION
This PR enables clap to read data from env vars as well as stdin.

It should solve #243 and is an alternative to #284.    
Compared to #284 it does not allow the token to be passed as a file.  
Also its lacking the documentation and tests that @shivaraj-bh has done in their PR.
