### PR TITLE
fix(client): use FSEvents instead of kqueue for watch-store on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,6 +2049,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
 dependencies = [
  "bitflags 2.9.1",
+ "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3.31"
 humantime = "2.2.0"
 indicatif = "0.18.0"
 lazy_static = "1.5.0"
-notify = { version = "8.1.0", default-features = false, features = ["macos_kqueue"] }
+notify = { version = "8.1.0", default-features = false, features = ["macos_fsevent"] }
 regex = "1.11.1"
 reqwest = { version = "0.12.22", default-features = false, features = ["json", "rustls-tls", "rustls-tls-native-roots", "stream"] }
 serde = { version = "1.0.219", features = ["derive"] }


### PR DESCRIPTION
watch-store did not work on my mac w/ 12k entries in /nix/store, error: "Too many open files" 

kqueue opens one file descriptor per entry when watching a directory recursively (via WalkDir).  On /nix/store with thousands of entries this quickly exceeds the per-process FD limit

FSEvents (macos_fsevent feature) uses a single system-level stream regardless of directory size or recursion depth.