### PR TITLE
Add options to include derivers and outputs

### DIFF
--- a/client/src/command/get_closure.rs
+++ b/client/src/command/get_closure.rs
@@ -16,6 +16,10 @@ pub struct GetClosure {
     /// For derivations, include their outputs.
     #[clap(long)]
     include_outputs: bool,
+
+    /// For outputs, include their derivers.
+    #[clap(long)]
+    include_derivers: bool,
 }
 
 pub async fn run(opts: Opts) -> Result<()> {
@@ -24,7 +28,7 @@ pub async fn run(opts: Opts) -> Result<()> {
     let store = NixStore::connect()?;
     let store_path = store.follow_store_path(&sub.store_path)?;
     let closure = store
-        .compute_fs_closure(store_path, false, sub.include_outputs, false)
+        .compute_fs_closure(store_path, false, sub.include_outputs, sub.include_derivers)
         .await?;
 
     for path in &closure {

--- a/client/src/command/push.rs
+++ b/client/src/command/push.rs
@@ -34,6 +34,14 @@ pub struct Push {
     #[clap(long)]
     no_closure: bool,
 
+    /// For derivations, include their outputs.
+    #[clap(long)]
+    include_outputs: bool,
+
+    /// For outputs, include their derivers.
+    #[clap(long)]
+    include_derivers: bool,
+
     /// Ignore the upstream cache filter.
     #[clap(long)]
     ignore_upstream_cache_filter: bool,
@@ -53,6 +61,8 @@ struct PushContext {
     server_name: ServerName,
     pusher: Pusher,
     no_closure: bool,
+    include_outputs: bool,
+    include_derivers: bool,
     ignore_upstream_cache_filter: bool,
 }
 
@@ -75,7 +85,7 @@ impl PushContext {
 
         let plan = self
             .pusher
-            .plan(roots, self.no_closure, self.ignore_upstream_cache_filter)
+            .plan(roots, self.no_closure, self.include_outputs, self.include_derivers, self.ignore_upstream_cache_filter)
             .await?;
 
         if plan.store_path_map.is_empty() {
@@ -113,6 +123,8 @@ impl PushContext {
     async fn push_stdin(self) -> Result<()> {
         let session = self.pusher.into_push_session(PushSessionConfig {
             no_closure: self.no_closure,
+            include_outputs: self.include_outputs,
+            include_derivers: self.include_derivers,
             ignore_upstream_cache_filter: self.ignore_upstream_cache_filter,
         });
 
@@ -178,6 +190,8 @@ pub async fn run(opts: Opts) -> Result<()> {
         server_name: server_name.clone(),
         pusher,
         no_closure: sub.no_closure,
+        include_outputs: sub.include_outputs,
+        include_derivers: sub.include_derivers,
         ignore_upstream_cache_filter: sub.ignore_upstream_cache_filter,
     };
 

--- a/client/src/command/watch_store.rs
+++ b/client/src/command/watch_store.rs
@@ -27,6 +27,14 @@ pub struct WatchStore {
     #[clap(long, hide = true)]
     no_closure: bool,
 
+    /// For derivations, include their outputs.
+    #[clap(long)]
+    include_outputs: bool,
+
+    /// For outputs, include their derivers.
+    #[clap(long)]
+    include_derivers: bool,
+
     /// Ignore the upstream cache filter.
     #[clap(long)]
     ignore_upstream_cache_filter: bool,
@@ -69,6 +77,8 @@ pub async fn run(opts: Opts) -> Result<()> {
 
     let push_session_config = PushSessionConfig {
         no_closure: sub.no_closure,
+        include_outputs: sub.include_outputs,
+        include_derivers: sub.include_derivers,
         ignore_upstream_cache_filter: sub.ignore_upstream_cache_filter,
     };
 

--- a/client/src/push.rs
+++ b/client/src/push.rs
@@ -58,6 +58,12 @@ pub struct PushSessionConfig {
     /// Push the specified paths only and do not compute closures.
     pub no_closure: bool,
 
+    /// Push the outputs of included derivations.
+    pub include_outputs: bool,
+
+    /// Push the derivers of selected paths.
+    pub include_derivers: bool,
+
     /// Ignore the upstream cache filter.
     pub ignore_upstream_cache_filter: bool,
 }
@@ -202,6 +208,8 @@ impl Pusher {
         &self,
         roots: Vec<StorePath>,
         no_closure: bool,
+        include_outputs: bool,
+        include_derivers: bool,
         ignore_upstream_filter: bool,
     ) -> Result<PushPlan> {
         PushPlan::plan(
@@ -211,6 +219,8 @@ impl Pusher {
             &self.cache_config,
             roots,
             no_closure,
+            include_outputs,
+            include_derivers,
             ignore_upstream_filter,
         )
         .await
@@ -348,6 +358,8 @@ impl PushSession {
                 .plan(
                     roots_vec,
                     config.no_closure,
+                    config.include_outputs,
+                    config.include_derivers,
                     config.ignore_upstream_cache_filter,
                 )
                 .await?;
@@ -409,6 +421,8 @@ impl PushPlan {
         cache_config: &CacheConfig,
         roots: Vec<StorePath>,
         no_closure: bool,
+        include_outputs: bool,
+        include_derivers: bool,
         ignore_upstream_filter: bool,
     ) -> Result<Self> {
         // Compute closure
@@ -416,7 +430,7 @@ impl PushPlan {
             roots
         } else {
             store
-                .compute_fs_closure_multi(roots, false, false, false)
+                .compute_fs_closure_multi(roots, false, include_outputs, include_derivers)
                 .await?
         };
 


### PR DESCRIPTION
This adds flags `--include-outputs` and `--include-derivers` to `attic push` and `attic watch-store` and plumbs them through to where the closure is computed.

Closes #206