### PR TITLE
Set user agent for all client API calls

### DIFF
--- a/client/src/api/mod.rs
+++ b/client/src/api/mod.rs
@@ -182,10 +182,7 @@ impl ApiClient {
         let endpoint = self.endpoint.join("_api/v1/upload-path")?;
         let upload_info_json = serde_json::to_string(&nar_info)?;
 
-        let mut req = self
-            .client
-            .put(endpoint)
-            .header(USER_AGENT, HeaderValue::from_str(ATTIC_USER_AGENT)?);
+        let mut req = self.client.put(endpoint);
 
         if force_preamble || upload_info_json.len() >= NAR_INFO_PREAMBLE_THRESHOLD {
             let preamble = Bytes::from(upload_info_json);
@@ -237,6 +234,8 @@ impl fmt::Display for StructuredApiError {
 
 fn build_http_client(token: Option<&str>) -> HttpClient {
     let mut headers = HeaderMap::new();
+
+    headers.insert(USER_AGENT, HeaderValue::from_str(ATTIC_USER_AGENT).unwrap());
 
     if let Some(token) = token {
         let auth_header = HeaderValue::from_str(&format!("bearer {}", token)).unwrap();


### PR DESCRIPTION
Previously, the user agent was only set on uploading. For consistency, I set the user-agent header as default for the client, so it is applied to all client requests.