### PR TITLE
nix_store: support Nix >= 2.29

### DIFF
--- a/attic/build.rs
+++ b/attic/build.rs
@@ -36,7 +36,7 @@ mod nix_store {
         let mut build = cxx_build::bridge("src/nix_store/bindings/mod.rs");
         build
             .file("src/nix_store/bindings/nix.cpp")
-            .flag("-std=c++2a")
+            .flag("-std=c++23")
             .flag("-O2")
             .includes(deps.all_include_paths());
 

--- a/attic/src/nix_store/bindings/nix-includes.hpp
+++ b/attic/src/nix_store/bindings/nix-includes.hpp
@@ -1,6 +1,10 @@
 #if defined(ATTIC_VARIANT_NIX)
 	#if NIX_VERSION >= 228
 		#include <nix/store/store-api.hh>
+		#if NIX_VERSION >= 229
+			#include <nix/store/store-open.hh>
+			#include <nix/store/globals.hh>
+		#endif
 		#include <nix/store/local-store.hh>
 		#include <nix/store/remote-store.hh>
 		#include <nix/store/uds-remote-store.hh>

--- a/attic/src/nix_store/bindings/nix.cpp
+++ b/attic/src/nix_store/bindings/nix.cpp
@@ -84,7 +84,7 @@ RString CPathInfo::ca() {
 // =========
 
 CNixStore::CNixStore() {
-	std::map<std::string, std::string> params;
+	nix::StoreReference::Params params;
 	std::lock_guard<std::mutex> lock(g_init_nix_mutex);
 
 	if (!g_init_nix_done) {


### PR DESCRIPTION
Nix 2.29 split `openStore()` into `<nix/store/store-open.hh>` and stopped pulling `<nix/store/globals.hh>` in via `store-api.hh`. Nix 2.31 changed `StoreReference::Params` to a transparent-comparator map and its public headers require C++23 (`std::views::zip`).

`nix::StoreReference::Params` has been the canonical alias since Nix 2.24, so the `nix.cpp` change is backwards-compatible.

Supersedes #291.