### PR TITLE
feat(jwt): add configurable time-tolerance for clock-skew tolerance

### DIFF
--- a/server/src/access/http.rs
+++ b/server/src/access/http.rs
@@ -108,6 +108,7 @@ pub async fn apply_auth(req: Request, next: Next) -> Response {
                 &signature_type,
                 &state.config.jwt.token_bound_issuer,
                 &state.config.jwt.token_bound_audiences,
+                state.config.jwt.time_tolerance,
             );
 
             if let Err(e) = &res_token {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -164,6 +164,20 @@ pub struct JWTConfig {
     #[serde(default = "load_jwt_signing_config_from_env")]
     #[debug(skip)]
     pub signing_config: JWTSigningConfig,
+
+    /// Clock-skew tolerance for JWT nbf/exp validation.
+    ///
+    /// Useful when the token issuer and atticd run with unsynchronised clocks,
+    /// e.g. microVM or container guests that boot without NTP. The tolerance
+    /// widens the acceptance window symmetrically -- it does not bypass exp.
+    ///
+    /// Example: time-tolerance = "30s"  (accepts "30s", "2m", "1h", ...)
+    ///
+    /// Default: no tolerance (existing behaviour preserved).
+    #[serde(rename = "time-tolerance")]
+    #[serde(default)]
+    #[serde(with = "humantime_serde::option")]
+    pub time_tolerance: Option<std::time::Duration>,
 }
 
 /// JSON Web Token signing configuration.

--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -250,6 +250,7 @@ impl Token {
         signature_type: &SignatureType,
         maybe_bound_issuer: &Option<String>,
         maybe_bound_audiences: &Option<HashSet<String>>,
+        time_tolerance: Option<std::time::Duration>,
     ) -> Result<Self> {
         let opts = VerificationOptions {
             reject_before: None,
@@ -263,7 +264,7 @@ impl Token {
                 .map(|s| [s.to_owned()].into())
                 .to_owned(),
             allowed_audiences: maybe_bound_audiences.to_owned(),
-            time_tolerance: None,
+            time_tolerance: time_tolerance.map(|d| Duration::from_secs(d.as_secs())),
             max_validity: None,
             max_token_length: None,
             max_header_length: None,


### PR DESCRIPTION
## Problem

`from_jwt` is called with `time_tolerance: None`, meaning JWT verification rejects any token whose `nbf` claim is even one second in the server's future. In practice, the token issuer and atticd rarely share a perfectly synchronised clock:

- A token minted inside WSL2 carries `nbf = WSL2_time`; atticd running in a microVM reads the host system clock. WSL2 can drift a few seconds from the Windows host clock.
- Containers and VMs that sync their clock from a hypervisor source may lag or lead the host by a few seconds depending on when the sync last ran.
- Any deployment where the CA / token-issuer host and the atticd host are on different NTP strata can see sub-minute skew.

RFC 7519 §4.1.5 explicitly acknowledges this:

> "Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew."

Without a configurable leeway there is no standards-compliant way to handle this; operators are forced to either accept spurious 401s or patch the binary.

## Change

Adds an optional `time-tolerance` field to the `[jwt]` section of `server.toml`:

```toml
[jwt]
time-tolerance = "30s"   # accepts "30s", "2m", "1h", ...
```

Threads through three files:

1. **`token/src/lib.rs`** — `from_jwt` gains an `Option<std::time::Duration>` parameter; mapped to `VerificationOptions` instead of hardcoded `None`
2. **`server/src/config.rs`** — `JWTConfig` gains `time_tolerance: Option<std::time::Duration>` with `humantime_serde::option` (already a server dependency)
3. **`server/src/access/http.rs`** — call site passes `state.config.jwt.time_tolerance`

## Design decisions

**Configurable, not hardcoded.** A hardcoded tolerance silently changes the security posture of every deployment. Making it opt-in means the default behaviour is unchanged and operators explicitly accept the trade-off.

**`humantime_serde`** was already a dependency of the server crate — no new deps added.

## Security note

`time-tolerance` widens the `nbf` acceptance window only. It does **not** bypass `exp`. A token with `validity = 1h` and `time-tolerance = 30s` is accepted for at most 1h 30s. For a private single-tenant cache a value of 30–60 seconds is the right trade-off; for a public cache operators should leave it unset (the default, preserving existing behaviour).

## Testing

Verified that `cargo build -p attic-server` compiles cleanly with these changes.

---

Happy to add a unit test or adjust the field name / defaults if you prefer a different approach.