### PR TITLE
integration-tests: Grant CREATE on schema public to atticd

### DIFF
--- a/integration-tests/basic/default.nix
+++ b/integration-tests/basic/default.nix
@@ -63,6 +63,7 @@ let
 
         systemd.services.postgresql-setup.postStart = lib.mkAfter ''
           psql -tAc 'ALTER DATABASE "attic" OWNER TO "atticd"'
+          psql -d attic -tAc 'GRANT CREATE ON SCHEMA public TO "atticd"'
         '';
 
         services.atticd.settings = {


### PR DESCRIPTION
PostgreSQL 15 removed the implicit CREATE grant on the public schema, so the atticd migration runner failed with "permission denied for schema public" even though it owns the database. Ownership of the database does not imply schema-level privileges, so grant CREATE on public explicitly.