### PR TITLE
Add configurable chunked uploads 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "cc",
+ "chrono",
  "criterion",
  "cxx",
  "cxx-build",
@@ -423,6 +424,7 @@ dependencies = [
  "system-deps",
  "tempfile",
  "tokio",
+ "uuid",
  "version-compare",
  "wildmatch",
 ]
@@ -433,6 +435,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-channel",
+ "async-stream",
  "attic",
  "bytes",
  "clap",
@@ -454,6 +457,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "xdg",
 ]
 

--- a/attic/Cargo.toml
+++ b/attic/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 async-stream = { version = "0.3.6", optional = true }
 base64 = "0.22.1"
 bytes = "1.10.1"
+chrono = { version = "0.4.41", features = ["serde"] }
 displaydoc = "0.2.5"
 digest = "0.11.3"
 ed25519-compact = "2.1.1"
@@ -22,6 +23,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_with = "3.14.0"
 sha2 = "0.11.0"
 tempfile = "3"
+uuid = { version = "1.17.0", features = ["serde", "v4"] }
 wildmatch = "2.4.0"
 
 # Native libnixstore bindings.

--- a/attic/src/api/v1/cache_config.rs
+++ b/attic/src/api/v1/cache_config.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::upload_path::UploadChunkingConfig;
 use crate::signing::NixKeypair;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -95,6 +96,12 @@ pub struct CacheConfig {
     /// The retention period of the cache.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retention_period: Option<RetentionPeriodConfig>,
+
+    /// Server-advertised chunked transport upload configuration.
+    ///
+    /// This is read-only and may not be available on older servers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upload_chunking: Option<UploadChunkingConfig>,
 }
 
 /// Configuaration of a keypair.
@@ -131,6 +138,7 @@ impl CacheConfig {
             priority: None,
             upstream_cache_key_names: None,
             retention_period: None,
+            upload_chunking: None,
         }
     }
 }

--- a/attic/src/api/v1/upload_path.rs
+++ b/attic/src/api/v1/upload_path.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnError, serde_as};
+use uuid::Uuid;
 
 use crate::cache::CacheName;
 use crate::hash::Hash;
@@ -25,7 +26,7 @@ pub const ATTIC_NAR_INFO_PREAMBLE_SIZE: &str = "X-Attic-Nar-Info-Preamble-Size";
 /// Regardless of client compression, the server will always decompress
 /// the NAR to validate the NAR hash before applying the server-configured
 /// compression again.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UploadPathNarInfo {
     /// The name of the binary cache to upload to.
     pub cache: CacheName,
@@ -64,8 +65,66 @@ pub struct UploadPathNarInfo {
     pub nar_size: usize,
 }
 
+/// Server-advertised configuration for chunked transport uploads.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UploadChunkingConfig {
+    /// Maximum transport part size in bytes.
+    pub max_chunk_size: usize,
+}
+
+/// Request to create a chunked transport upload session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StartUploadPathSessionRequest {
+    /// NAR information for the object being uploaded.
+    pub nar_info: UploadPathNarInfo,
+
+    /// Requested transport part size in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk_size: Option<usize>,
+}
+
+/// Response returned when starting a chunked transport upload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum StartUploadPathSessionResponse {
+    /// A new upload session was created and the client should upload parts.
+    Session {
+        /// Upload session ID.
+        session_id: Uuid,
+
+        /// Transport part size selected by the server.
+        chunk_size: usize,
+    },
+
+    /// The upload completed immediately without creating a session.
+    Completed {
+        /// Upload result.
+        result: UploadPathResult,
+    },
+}
+
+/// Response returned when finalizing a chunked transport upload session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum FinalizeUploadSessionResponse {
+    /// Finalization is running in the background. The client should poll again.
+    Pending,
+
+    /// Finalization failed permanently.
+    Failed {
+        /// Human-readable reason.
+        message: String,
+    },
+
+    /// Finalization completed.
+    Completed {
+        /// Upload result.
+        result: UploadPathResult,
+    },
+}
+
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UploadPathResult {
     #[serde_as(deserialize_as = "DefaultOnError")]
     pub kind: UploadPathResultKind,
@@ -78,7 +137,7 @@ pub struct UploadPathResult {
     pub frac_deduplicated: Option<f64>,
 }
 
-#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum UploadPathResultKind {
     /// The path was uploaded.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 attic = { path = "../attic" }
 
 anyhow = "1.0.98"
+async-stream = "0.3.6"
 async-channel = "2.5.0"
 bytes = "1.10.1"
 clap = { version = "4.5", features = ["derive"] }
@@ -32,6 +33,7 @@ serde_json = "1.0.140"
 toml = "1.1.2"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
+uuid = "1.17.0"
 xdg = "3.0.0"
 
 [dependencies.tokio]

--- a/client/src/api/mod.rs
+++ b/client/src/api/mod.rs
@@ -1,5 +1,7 @@
 use std::error::Error as StdError;
 use std::fmt;
+use std::io;
+use std::sync::Arc;
 
 use anyhow::Result;
 use bytes::Bytes;
@@ -20,7 +22,9 @@ use crate::version::ATTIC_DISTRIBUTOR;
 use attic::api::v1::cache_config::{CacheConfig, CreateCacheRequest};
 use attic::api::v1::get_missing_paths::{GetMissingPathsRequest, GetMissingPathsResponse};
 use attic::api::v1::upload_path::{
-    ATTIC_NAR_INFO, ATTIC_NAR_INFO_PREAMBLE_SIZE, UploadPathNarInfo, UploadPathResult,
+    ATTIC_NAR_INFO, ATTIC_NAR_INFO_PREAMBLE_SIZE, FinalizeUploadSessionResponse,
+    StartUploadPathSessionRequest, StartUploadPathSessionResponse, UploadPathNarInfo,
+    UploadPathResult,
 };
 use attic::cache::CacheName;
 use attic::nix_store::StorePathHash;
@@ -31,6 +35,7 @@ const ATTIC_USER_AGENT: &str =
 
 /// The size threshold to send the upload info as part of the PUT body.
 const NAR_INFO_PREAMBLE_THRESHOLD: usize = 4 * 1024; // 4 KiB
+const UPLOAD_PROGRESS_CHUNK_SIZE: usize = 128 * 1024;
 
 /// The Attic API client.
 #[derive(Debug, Clone)]
@@ -211,11 +216,128 @@ impl ApiClient {
             Err(api_error.into())
         }
     }
+
+    /// Starts a chunked transport upload session.
+    pub async fn start_upload_session(
+        &self,
+        nar_info: UploadPathNarInfo,
+        chunk_size: Option<usize>,
+    ) -> Result<StartUploadPathSessionResponse> {
+        let endpoint = self.endpoint.join("_api/v1/upload-path/sessions")?;
+        let payload = StartUploadPathSessionRequest {
+            nar_info,
+            chunk_size,
+        };
+
+        let res = self.client.post(endpoint).json(&payload).send().await?;
+        if res.status().is_success() {
+            Ok(res.json().await?)
+        } else {
+            let api_error = ApiError::try_from_response(res).await?;
+            Err(api_error.into())
+        }
+    }
+
+    /// Uploads a chunked transport upload session part, reporting body bytes as
+    /// they are sent to the HTTP client.
+    pub async fn upload_session_part_with_progress<F>(
+        &self,
+        session_id: uuid::Uuid,
+        seq: u32,
+        bytes: Bytes,
+        on_progress: F,
+    ) -> Result<()>
+    where
+        F: Fn(u64) + Send + Sync + 'static,
+    {
+        let endpoint = self.endpoint.join(&format!(
+            "_api/v1/upload-path/sessions/{}/parts/{}",
+            session_id, seq
+        ))?;
+
+        let body_len = bytes.len();
+        let on_progress = Arc::new(on_progress);
+        let body_stream = stream::unfold((bytes, 0), move |(bytes, offset)| {
+            let on_progress = on_progress.clone();
+            async move {
+                if offset >= body_len {
+                    return None;
+                }
+
+                let end = (offset + UPLOAD_PROGRESS_CHUNK_SIZE).min(body_len);
+                let chunk = bytes.slice(offset..end);
+                on_progress(chunk.len() as u64);
+                Some((Ok::<_, io::Error>(chunk), (bytes, end)))
+            }
+        });
+
+        let res = self
+            .client
+            .put(endpoint)
+            .body(Body::wrap_stream(body_stream))
+            .send()
+            .await?;
+        if res.status().is_success() {
+            Ok(())
+        } else {
+            let api_error = ApiError::try_from_response(res).await?;
+            Err(api_error.into())
+        }
+    }
+
+    /// Finalizes a chunked transport upload session.
+    pub async fn finalize_upload_session(
+        &self,
+        session_id: uuid::Uuid,
+    ) -> Result<FinalizeUploadSessionResponse> {
+        let endpoint = self.endpoint.join(&format!(
+            "_api/v1/upload-path/sessions/{}/finalize",
+            session_id
+        ))?;
+
+        let res = self.client.post(endpoint).send().await?;
+        if res.status().is_success() {
+            Ok(res.json().await?)
+        } else {
+            let api_error = ApiError::try_from_response(res).await?;
+            Err(api_error.into())
+        }
+    }
+
+    /// Aborts a chunked transport upload session.
+    pub async fn abort_upload_session(&self, session_id: uuid::Uuid) -> Result<()> {
+        let endpoint = self
+            .endpoint
+            .join(&format!("_api/v1/upload-path/sessions/{}", session_id))?;
+
+        let res = self.client.delete(endpoint).send().await?;
+        if res.status().is_success() {
+            Ok(())
+        } else {
+            let api_error = ApiError::try_from_response(res).await?;
+            Err(api_error.into())
+        }
+    }
 }
 
 impl StdError for ApiError {}
 
 impl ApiError {
+    pub fn status_code(&self) -> Option<StatusCode> {
+        match self {
+            Self::Structured(error) => StatusCode::from_u16(error.code).ok(),
+            Self::Unstructured(status, _) => Some(*status),
+        }
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        self.status_code().is_some_and(|status| {
+            status == StatusCode::REQUEST_TIMEOUT
+                || status == StatusCode::TOO_MANY_REQUESTS
+                || status.is_server_error()
+        })
+    }
+
     async fn try_from_response(response: Response) -> Result<Self> {
         let status = response.status();
         let text = response.text().await?;

--- a/client/src/command/push.rs
+++ b/client/src/command/push.rs
@@ -42,6 +42,10 @@ pub struct Push {
     #[clap(short = 'j', long, default_value = "5")]
     jobs: usize,
 
+    /// The maximum size of each uploaded part in bytes.
+    #[clap(long)]
+    chunk_size: Option<usize>,
+
     /// Always send the upload info as part of the payload.
     #[clap(long, hide = true)]
     force_preamble: bool,
@@ -140,7 +144,9 @@ pub async fn run(opts: Opts) -> Result<()> {
     if sub.jobs == 0 {
         return Err(anyhow!("The number of jobs cannot be 0"));
     }
-
+    if sub.chunk_size == Some(0) {
+        return Err(anyhow!("The chunk size cannot be 0"));
+    }
     let config = Config::load()?;
 
     let store = Arc::new(NixStore::connect()?);
@@ -160,6 +166,7 @@ pub async fn run(opts: Opts) -> Result<()> {
     let push_config = PushConfig {
         num_workers: sub.jobs,
         force_preamble: sub.force_preamble,
+        chunk_size: sub.chunk_size,
     };
 
     let mp = MultiProgress::new();

--- a/client/src/command/watch_store.rs
+++ b/client/src/command/watch_store.rs
@@ -35,6 +35,10 @@ pub struct WatchStore {
     #[clap(short = 'j', long, default_value = "5")]
     jobs: usize,
 
+    /// The maximum size of each uploaded part in bytes.
+    #[clap(long)]
+    chunk_size: Option<usize>,
+
     /// Always send the upload info as part of the payload.
     #[clap(long, hide = true)]
     force_preamble: bool,
@@ -45,7 +49,9 @@ pub async fn run(opts: Opts) -> Result<()> {
     if sub.jobs == 0 {
         return Err(anyhow!("The number of jobs cannot be 0"));
     }
-
+    if sub.chunk_size == Some(0) {
+        return Err(anyhow!("The chunk size cannot be 0"));
+    }
     let config = Config::load()?;
 
     let store = Arc::new(NixStore::connect()?);
@@ -65,6 +71,7 @@ pub async fn run(opts: Opts) -> Result<()> {
     let push_config = PushConfig {
         num_workers: sub.jobs,
         force_preamble: sub.force_preamble,
+        chunk_size: sub.chunk_size,
     };
 
     let push_session_config = PushSessionConfig {

--- a/client/src/push.rs
+++ b/client/src/push.rs
@@ -19,12 +19,13 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
 use async_channel as channel;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use futures::future::join_all;
 use futures::stream::{Stream, TryStreamExt};
 use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressState, ProgressStyle};
@@ -32,9 +33,12 @@ use tokio::sync::{Mutex, mpsc};
 use tokio::task::{JoinHandle, spawn};
 use tokio::time;
 
-use crate::api::ApiClient;
+use crate::api::{ApiClient, ApiError};
 use attic::api::v1::cache_config::CacheConfig;
-use attic::api::v1::upload_path::{UploadPathNarInfo, UploadPathResult, UploadPathResultKind};
+use attic::api::v1::upload_path::{
+    FinalizeUploadSessionResponse, StartUploadPathSessionResponse, UploadChunkingConfig,
+    UploadPathNarInfo, UploadPathResult, UploadPathResultKind,
+};
 use attic::cache::CacheName;
 use attic::error::AtticResult;
 use attic::nix_store::{NixStore, StorePath, StorePathHash, ValidPathInfo};
@@ -50,6 +54,9 @@ pub struct PushConfig {
 
     /// Whether to always include the upload info in the PUT payload.
     pub force_preamble: bool,
+
+    /// Maximum size of each transport upload part.
+    pub chunk_size: Option<usize>,
 }
 
 /// Configuration for a push session.
@@ -141,6 +148,11 @@ struct NarStreamProgress<S> {
     bar: ProgressBar,
 }
 
+struct UploadProgress {
+    bar: ProgressBar,
+    uploaded: AtomicU64,
+}
+
 impl Pusher {
     pub fn new(
         store: Arc<NixStore>,
@@ -159,6 +171,7 @@ impl Pusher {
                 store.clone(),
                 api.clone(),
                 cache.clone(),
+                cache_config.upload_chunking.clone(),
                 mp.clone(),
                 config,
             )));
@@ -228,6 +241,7 @@ impl Pusher {
         store: Arc<NixStore>,
         api: ApiClient,
         cache: CacheName,
+        upload_chunking: Option<UploadChunkingConfig>,
         mp: MultiProgress,
         config: PushConfig,
     ) -> HashMap<StorePath, Result<()>> {
@@ -249,8 +263,9 @@ impl Pusher {
                 store.clone(),
                 api.clone(),
                 &cache,
+                upload_chunking.clone(),
                 mp.clone(),
-                config.force_preamble,
+                config,
             )
             .await;
 
@@ -499,8 +514,9 @@ pub async fn upload_path(
     store: Arc<NixStore>,
     api: ApiClient,
     cache: &CacheName,
+    upload_chunking: Option<UploadChunkingConfig>,
     mp: MultiProgress,
-    force_preamble: bool,
+    config: PushConfig,
 ) -> Result<()> {
     let path = &path_info.path;
     let upload_info = {
@@ -535,7 +551,7 @@ pub async fn upload_path(
     };
 
     let template = format!(
-        "{{spinner}} {: <20.20} {{bar:40.green/blue}} {{human_bytes:10}} ({{average_speed}})",
+        "{{spinner}} {: <20.20} {{bar:40.green/blue}} {{human_bytes:10}} ({{average_speed}}) {{msg}}",
         path.name(),
     );
     let style = ProgressStyle::with_template(&template)
@@ -558,14 +574,53 @@ pub async fn upload_path(
         );
     let bar = mp.add(ProgressBar::new(path_info.nar_size));
     bar.set_style(style);
-    let nar_stream = NarStreamProgress::new(store.nar_from_path(path.to_owned()), bar.clone())
-        .map_ok(Bytes::from);
+    let nar_stream = || store.nar_from_path(path.to_owned());
 
     let start = Instant::now();
-    match api
-        .upload_path(upload_info, nar_stream, force_preamble)
+    let upload_chunking = upload_chunking.filter(|c| c.max_chunk_size > 0);
+    if config.chunk_size.is_some() && upload_chunking.is_none() {
+        return Err(anyhow!("Chunked transport upload is not enabled by server"));
+    }
+
+    let upload_result = if let Some(upload_chunking) = upload_chunking {
+        let chunk_size = match config.chunk_size {
+            Some(chunk_size) if chunk_size > upload_chunking.max_chunk_size => {
+                return Err(anyhow!("Chunk size exceeds server limit"));
+            }
+            Some(chunk_size) => chunk_size,
+            None => upload_chunking.max_chunk_size,
+        };
+
+        if (path_info.nar_size as usize) <= chunk_size.max(1) {
+            api.upload_path(
+                upload_info,
+                NarStreamProgress::new(nar_stream(), bar.clone()).map_ok(Bytes::from),
+                config.force_preamble,
+            )
+            .await
+        } else {
+            let progress = Arc::new(UploadProgress::new(bar.clone()));
+
+            upload_path_chunked(
+                &api,
+                upload_info,
+                nar_stream().map_ok(Bytes::from),
+                chunk_size,
+                progress,
+            )
+            .await
+            .map(Some)
+        }
+    } else {
+        api.upload_path(
+            upload_info,
+            NarStreamProgress::new(nar_stream(), bar.clone()).map_ok(Bytes::from),
+            config.force_preamble,
+        )
         .await
-    {
+    };
+
+    match upload_result {
         Ok(r) => {
             let r = r.unwrap_or(UploadPathResult {
                 kind: UploadPathResultKind::Uploaded,
@@ -613,9 +668,120 @@ pub async fn upload_path(
     }
 }
 
+async fn upload_path_chunked<S>(
+    api: &ApiClient,
+    upload_info: UploadPathNarInfo,
+    stream: S,
+    chunk_size: usize,
+    progress: Arc<UploadProgress>,
+) -> Result<UploadPathResult>
+where
+    S: Stream<Item = AtticResult<Bytes>> + Send + 'static,
+{
+    let session = api
+        .start_upload_session(upload_info, Some(chunk_size))
+        .await?;
+    let (session_id, chunk_size) = match session {
+        StartUploadPathSessionResponse::Session {
+            session_id,
+            chunk_size,
+            ..
+        } => (session_id, chunk_size),
+        StartUploadPathSessionResponse::Completed { result } => return Ok(result),
+    };
+    let part_stream = byte_chunker(stream, chunk_size.max(1));
+    futures::pin_mut!(part_stream);
+
+    while let Some((seq, bytes)) = match part_stream.try_next().await {
+        Ok(part) => part,
+        Err(e) => {
+            let _ = api.abort_upload_session(session_id).await;
+            return Err(e);
+        }
+    } {
+        let upload_progress = progress.clone();
+        if let Err(e) = api
+            .upload_session_part_with_progress(session_id, seq, bytes, move |len| {
+                upload_progress.add(len);
+            })
+            .await
+        {
+            let _ = api.abort_upload_session(session_id).await;
+            return Err(e);
+        }
+    }
+
+    progress.set_message("finalizing");
+    let mut error_delay = Duration::from_secs(1);
+    loop {
+        match api.finalize_upload_session(session_id).await {
+            Ok(FinalizeUploadSessionResponse::Completed { result }) => return Ok(result),
+            Ok(FinalizeUploadSessionResponse::Failed { message }) => return Err(anyhow!(message)),
+            Ok(FinalizeUploadSessionResponse::Pending) => {
+                error_delay = Duration::from_secs(1);
+                time::sleep(Duration::from_secs(2)).await;
+            }
+            Err(e) => {
+                if e.downcast_ref::<ApiError>()
+                    .is_some_and(|e| !e.is_retryable())
+                {
+                    return Err(e);
+                }
+
+                progress.set_message("finalizing (retrying)");
+                time::sleep(error_delay).await;
+                error_delay = (error_delay * 2).min(Duration::from_secs(30));
+                progress.set_message("finalizing");
+            }
+        }
+    }
+}
+
+fn byte_chunker<S>(stream: S, chunk_size: usize) -> impl Stream<Item = Result<(u32, Bytes)>>
+where
+    S: Stream<Item = AtticResult<Bytes>> + Send + 'static,
+{
+    async_stream::try_stream! {
+        futures::pin_mut!(stream);
+        let mut seq = 0u32;
+        let mut buffer = BytesMut::new();
+
+        while let Some(bytes) = stream.try_next().await? {
+            buffer.extend_from_slice(&bytes);
+            while buffer.len() >= chunk_size {
+                let chunk = buffer.split_to(chunk_size).freeze();
+                yield (seq, chunk);
+                seq = seq.checked_add(1).ok_or_else(|| anyhow!("Too many upload parts"))?;
+            }
+        }
+
+        if !buffer.is_empty() {
+            yield (seq, buffer.freeze());
+        }
+    }
+}
+
 impl<S: Stream<Item = AtticResult<Vec<u8>>>> NarStreamProgress<S> {
     fn new(stream: S, bar: ProgressBar) -> Self {
         Self { stream, bar }
+    }
+}
+
+impl UploadProgress {
+    fn new(bar: ProgressBar) -> Self {
+        Self {
+            bar,
+            uploaded: AtomicU64::new(0),
+        }
+    }
+
+    fn add(&self, amount: u64) {
+        let new_position = self.uploaded.fetch_add(amount, Ordering::Relaxed) + amount;
+        self.bar.set_position(new_position);
+    }
+
+    fn set_message(&self, message: &'static str) {
+        self.bar.set_message(message);
     }
 }
 
@@ -641,4 +807,64 @@ impl<S: Stream<Item = AtticResult<Vec<u8>>> + Unpin> Stream for NarStreamProgres
 fn average_speed(bytes: u64, duration: Duration) -> String {
     let speed = bytes as f64 * 1000_f64 / duration.as_millis() as f64;
     format!("{}/s", HumanBytes(speed as u64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use futures::stream;
+
+    #[tokio::test]
+    async fn byte_chunker_splits_fragmented_stream_into_fixed_parts() {
+        let input = stream::iter([
+            Ok(Bytes::from_static(b"ab")),
+            Ok(Bytes::from_static(b"cdefg")),
+            Ok(Bytes::from_static(b"hij")),
+        ]);
+
+        let chunks = byte_chunker(input, 4)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            chunks,
+            vec![
+                (0, Bytes::from_static(b"abcd")),
+                (1, Bytes::from_static(b"efgh")),
+                (2, Bytes::from_static(b"ij")),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn byte_chunker_does_not_emit_empty_tail_for_exact_multiple() {
+        let input = stream::iter([Ok(Bytes::from_static(b"abcdefgh"))]);
+
+        let chunks = byte_chunker(input, 4)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            chunks,
+            vec![
+                (0, Bytes::from_static(b"abcd")),
+                (1, Bytes::from_static(b"efgh")),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn byte_chunker_emits_no_parts_for_empty_stream() {
+        let input = stream::empty();
+
+        let chunks = byte_chunker(input, 4)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert!(chunks.is_empty());
+    }
 }

--- a/client/src/push.rs
+++ b/client/src/push.rs
@@ -628,14 +628,17 @@ pub async fn upload_path(
                 frac_deduplicated: None,
             });
 
+            let total_size = HumanBytes(path_info.nar_size).to_string();
             let info_string: String = match r.kind {
-                UploadPathResultKind::Deduplicated => "deduplicated".to_string(),
+                UploadPathResultKind::Deduplicated => {
+                    format!("{}, deduplicated", total_size)
+                }
                 _ => {
                     let elapsed = start.elapsed();
                     let seconds = elapsed.as_secs_f64();
                     let speed = (path_info.nar_size as f64 / seconds) as u64;
 
-                    let mut s = format!("{}/s", HumanBytes(speed));
+                    let mut s = format!("{}, {}/s", total_size, HumanBytes(speed));
 
                     if let Some(frac_deduplicated) = r.frac_deduplicated
                         && frac_deduplicated > 0.01f64

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -57,7 +57,7 @@ tower-http = { version = "0.7.0", features = [ "catch-panic", "trace" ] }
 tracing = "0.1.41"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = [ "json" ] }
-uuid = { version = "1.17.0", features = ["v4"] }
+uuid = { version = "1.17.0", features = ["serde", "v4"] }
 console-subscriber = "0.5.0"
 xdg = "3.0.0"
 rsa = "0.10.0-rc.18"

--- a/server/src/api/v1/cache_config.rs
+++ b/server/src/api/v1/cache_config.rs
@@ -15,6 +15,7 @@ use crate::{RequestState, State};
 use attic::api::v1::cache_config::{
     CacheConfig, CreateCacheRequest, KeypairConfig, RetentionPeriodConfig,
 };
+use attic::api::v1::upload_path::UploadChunkingConfig;
 use attic::cache::CacheName;
 use attic::signing::NixKeypair;
 
@@ -41,6 +42,15 @@ pub(crate) async fn get_cache_config(
         RetentionPeriodConfig::Global
     };
 
+    let upload_chunking = state
+        .config
+        .upload
+        .max_chunk_size
+        .filter(|max_part_size| *max_part_size > 0)
+        .map(|max_part_size| UploadChunkingConfig {
+            max_chunk_size: max_part_size,
+        });
+
     Ok(Json(CacheConfig {
         substituter_endpoint: Some(req_state.substituter_endpoint(cache_name)?),
         api_endpoint: Some(req_state.api_endpoint()?),
@@ -51,6 +61,7 @@ pub(crate) async fn get_cache_config(
         priority: Some(cache.priority),
         upstream_cache_key_names: Some(cache.upstream_cache_key_names.0),
         retention_period: Some(retention_period_config),
+        upload_chunking,
     }))
 }
 
@@ -169,6 +180,10 @@ pub(crate) async fn destroy_cache(
         }
     } else {
         // Perform hard deletion
+        crate::gc::delete_upload_sessions_for_cache(&state, cache.id)
+            .await
+            .map_err(|e| ServerError::from(ErrorKind::RequestError(e)))?;
+
         let deletion = Cache::delete_many()
             .filter(cache::Column::Id.eq(cache.id))
             .filter(cache::Column::DeletedAt.is_null()) // don't operate on soft-deleted caches

--- a/server/src/api/v1/mod.rs
+++ b/server/src/api/v1/mod.rs
@@ -15,6 +15,22 @@ pub(crate) fn get_router() -> Router {
         )
         .route("/_api/v1/upload-path", put(upload_path::upload_path))
         .route(
+            "/_api/v1/upload-path/sessions",
+            post(upload_path::start_upload_session),
+        )
+        .route(
+            "/_api/v1/upload-path/sessions/{session}/parts/{seq}",
+            put(upload_path::upload_session_part),
+        )
+        .route(
+            "/_api/v1/upload-path/sessions/{session}/finalize",
+            post(upload_path::finalize_upload_session),
+        )
+        .route(
+            "/_api/v1/upload-path/sessions/{session}",
+            delete(upload_path::abort_upload_session),
+        )
+        .route(
             "/{cache}/attic-cache-info",
             get(cache_config::get_cache_config),
         )

--- a/server/src/api/v1/upload_path.rs
+++ b/server/src/api/v1/upload_path.rs
@@ -1,15 +1,16 @@
 use std::io;
-
 use std::io::Cursor;
 use std::marker::Unpin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::anyhow;
 use async_compression::Level as CompressionLevel;
 use async_compression::tokio::bufread::{BrotliEncoder, XzEncoder, ZstdEncoder};
+use async_stream::try_stream;
 use axum::{
     body::Body,
-    extract::{Extension, Json},
+    extract::{Extension, Json, Path},
     http::HeaderMap,
 };
 use bytes::{Bytes, BytesMut};
@@ -18,12 +19,13 @@ use futures::StreamExt;
 use futures::future::join_all;
 use sea_orm::ActiveValue::Set;
 use sea_orm::entity::prelude::*;
-use sea_orm::{QuerySelect, TransactionTrait};
+use sea_orm::{PaginatorTrait, QueryOrder, QuerySelect, TransactionTrait};
 use sha2::{Digest, Sha256};
-use tokio::io::{AsyncBufRead, AsyncReadExt};
+use tokio::io::{AsyncBufRead, AsyncRead, AsyncReadExt};
 use tokio::sync::Semaphore;
-use tokio::task::spawn;
-use tokio_util::io::StreamReader;
+use tokio::task::{JoinHandle, spawn};
+use tokio::time;
+use tokio_util::io::{ReaderStream, StreamReader};
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -34,8 +36,9 @@ use crate::narinfo::Compression;
 use crate::storage::StorageBackend;
 use crate::{RequestState, State};
 use attic::api::v1::upload_path::{
-    ATTIC_NAR_INFO, ATTIC_NAR_INFO_PREAMBLE_SIZE, UploadPathNarInfo, UploadPathResult,
-    UploadPathResultKind,
+    ATTIC_NAR_INFO, ATTIC_NAR_INFO_PREAMBLE_SIZE, FinalizeUploadSessionResponse,
+    StartUploadPathSessionRequest, StartUploadPathSessionResponse, UploadPathNarInfo,
+    UploadPathResult, UploadPathResultKind,
 };
 use attic::chunking::chunk_stream;
 use attic::hash::Hash;
@@ -48,13 +51,21 @@ use crate::database::entity::chunk::{self, ChunkState, Entity as Chunk};
 use crate::database::entity::chunkref::{self, Entity as ChunkRef};
 use crate::database::entity::nar::{self, Entity as Nar, NarState};
 use crate::database::entity::object::{self, Entity as Object, InsertExt};
+use crate::database::entity::upload_session::{self, Entity as UploadSession, UploadSessionState};
+use crate::database::entity::upload_session_part::{
+    self, Entity as UploadSessionPart, UploadSessionPartState,
+};
 use crate::database::{AtticDatabase, ChunkGuard, NarGuard};
+use crate::storage::{Download, RemoteFile};
 
 /// Number of chunks to upload to the storage backend at once.
 ///
 /// TODO: Make this configurable
 const CONCURRENT_CHUNK_UPLOADS: usize = 10;
 
+const UPLOAD_SESSION_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const UPLOAD_SESSION_FINALIZE_STALE_AFTER: Duration = Duration::from_secs(2 * 60);
+const UPLOAD_SESSION_FINALIZE_HEARTBEAT: Duration = Duration::from_secs(60);
 /// Data of a chunk.
 enum ChunkData {
     /// Some bytes in memory.
@@ -136,6 +147,16 @@ pub(crate) async fn upload_path(
             return Err(ErrorKind::RequestError(anyhow!("{} must be set", ATTIC_NAR_INFO)).into());
         }
     };
+
+    ingest_upload_path(state, req_state, upload_info, stream).await
+}
+
+async fn ingest_upload_path(
+    state: State,
+    req_state: RequestState,
+    upload_info: UploadPathNarInfo,
+    stream: impl AsyncBufRead + Send + Unpin + 'static,
+) -> ServerResult<Json<UploadPathResult>> {
     let cache_name = &upload_info.cache;
 
     let database = state.database().await?;
@@ -177,6 +198,539 @@ pub(crate) async fn upload_path(
     }
 
     upload_path_new(username, cache, upload_info, stream, database, &state).await
+}
+
+/// Starts a chunked transport upload session.
+#[instrument(skip_all)]
+pub(crate) async fn start_upload_session(
+    Extension(state): Extension<State>,
+    Extension(req_state): Extension<RequestState>,
+    Json(request): Json<StartUploadPathSessionRequest>,
+) -> ServerResult<Json<StartUploadPathSessionResponse>> {
+    let upload_info = request.nar_info;
+    let cache_name = &upload_info.cache;
+    let database = state.database().await?;
+    let cache = req_state
+        .auth
+        .auth_cache(database, cache_name, |cache, permission| {
+            permission.require_push()?;
+            Ok(cache)
+        })
+        .await?;
+
+    if !state.config.require_proof_of_possession
+        && let Some(existing_nar) = database.find_and_lock_nar(&upload_info.nar_hash).await?
+    {
+        let missing_chunk = ChunkRef::find()
+            .filter(chunkref::Column::NarId.eq(existing_nar.id))
+            .filter(chunkref::Column::ChunkId.is_null())
+            .limit(1)
+            .one(database)
+            .await
+            .map_err(ServerError::database_error)?;
+
+        if missing_chunk.is_none() {
+            let Json(result) = upload_path_dedup(
+                req_state.auth.username().map(str::to_string),
+                cache,
+                upload_info,
+                Cursor::new(Bytes::new()),
+                database,
+                &state,
+                existing_nar,
+            )
+            .await?;
+
+            return Ok(Json(StartUploadPathSessionResponse::Completed { result }));
+        }
+    }
+
+    let max_part_size = state
+        .config
+        .upload
+        .max_chunk_size
+        .filter(|size| *size > 0)
+        .ok_or_else(|| {
+            ErrorKind::RequestError(anyhow!("Chunked transport upload is not enabled"))
+        })?;
+    let chunk_size = request.chunk_size.unwrap_or(max_part_size);
+    if chunk_size == 0 {
+        return Err(ErrorKind::RequestError(anyhow!("Chunk size cannot be 0")).into());
+    }
+    if chunk_size > max_part_size {
+        return Err(ErrorKind::RequestError(anyhow!("Chunk size exceeds server limit")).into());
+    }
+
+    let expected_parts = if upload_info.nar_size == 0 {
+        0
+    } else {
+        upload_info.nar_size.div_ceil(chunk_size)
+    };
+    let now = Utc::now();
+    let expires_at =
+        now + chrono::Duration::from_std(UPLOAD_SESSION_TTL).map_err(ServerError::request_error)?;
+    let session_id = Uuid::new_v4();
+
+    UploadSession::insert(upload_session::ActiveModel {
+        id: Set(session_id.to_string()),
+        cache_id: Set(cache.id),
+        upload_info: Set(serde_json::to_string(&upload_info).map_err(ServerError::request_error)?),
+        expected_parts: Set(i32::try_from(expected_parts).map_err(ServerError::request_error)?),
+        state: Set(UploadSessionState::Uploading.as_str().to_string()),
+        created_by: Set(req_state.auth.username().map(str::to_string)),
+        created_at: Set(now),
+        updated_at: Set(now),
+        expires_at: Set(expires_at),
+        ..Default::default()
+    })
+    .exec(database)
+    .await
+    .map_err(ServerError::database_error)?;
+
+    Ok(Json(StartUploadPathSessionResponse::Session {
+        session_id,
+        chunk_size,
+    }))
+}
+
+/// Uploads a chunked transport upload session part.
+#[instrument(skip_all, fields(session_id = %session_id, seq))]
+pub(crate) async fn upload_session_part(
+    Extension(state): Extension<State>,
+    Extension(req_state): Extension<RequestState>,
+    Path((session_id, seq)): Path<(Uuid, u32)>,
+    body: Body,
+) -> ServerResult<()> {
+    let database = state.database().await?;
+    let session = load_session(database, session_id).await?;
+    let upload_info = parse_upload_info(&session)?;
+    req_state
+        .auth
+        .auth_cache(database, &upload_info.cache, |_, permission| {
+            permission.require_push()?;
+            Ok(())
+        })
+        .await?;
+
+    if session.state != UploadSessionState::Uploading.as_str() {
+        return Err(
+            ErrorKind::RequestError(anyhow!("Upload session is not accepting parts")).into(),
+        );
+    }
+    if Utc::now() > session.expires_at {
+        return Err(ErrorKind::RequestError(anyhow!("Upload session has expired")).into());
+    }
+    let update = UploadSession::update_many()
+        .col_expr(upload_session::Column::UpdatedAt, Expr::value(Utc::now()))
+        .filter(upload_session::Column::Id.eq(session.id.clone()))
+        .filter(upload_session::Column::State.eq(UploadSessionState::Uploading.as_str()))
+        .exec(database)
+        .await
+        .map_err(ServerError::database_error)?;
+    if update.rows_affected != 1 {
+        return Err(
+            ErrorKind::RequestError(anyhow!("Upload session is not accepting parts")).into(),
+        );
+    }
+
+    let expected_parts =
+        usize::try_from(session.expected_parts).map_err(ServerError::request_error)?;
+    let seq_usize = usize::try_from(seq).map_err(ServerError::request_error)?;
+    let seq_db = i32::try_from(seq).map_err(ServerError::request_error)?;
+    if seq_usize >= expected_parts {
+        return Err(ErrorKind::RequestError(anyhow!("Part sequence is out of range")).into());
+    }
+
+    let backend = state.storage().await?;
+
+    let key = format!(
+        "upload-session/{}/{}-{}.part",
+        session.id,
+        seq,
+        Uuid::new_v4()
+    );
+    let remote_file = backend.make_db_reference(key.clone()).await?;
+
+    let now = Utc::now();
+    let insert_result = UploadSessionPart::insert(upload_session_part::ActiveModel {
+        session_id: Set(session.id.clone()),
+        seq: Set(seq_db),
+        state: Set(UploadSessionPartState::Pending.as_str().to_string()),
+        remote_file: Set(serde_json::to_string(&remote_file).map_err(ServerError::request_error)?),
+        created_at: Set(now),
+        ..Default::default()
+    })
+    .exec(database)
+    .await;
+
+    let insert_result = match insert_result {
+        Ok(insert_result) => insert_result,
+        Err(e) => {
+            if let Some(existing) = UploadSessionPart::find()
+                .filter(upload_session_part::Column::SessionId.eq(session.id.clone()))
+                .filter(upload_session_part::Column::Seq.eq(seq_db))
+                .one(database)
+                .await
+                .map_err(ServerError::database_error)?
+            {
+                if existing.state == UploadSessionPartState::Pending.as_str() {
+                    return Err(ErrorKind::RequestError(anyhow!(
+                        "Part upload is already in progress"
+                    ))
+                    .into());
+                }
+
+                return Err(
+                    ErrorKind::RequestError(anyhow!("Part has already been uploaded")).into(),
+                );
+            }
+
+            return Err(ServerError::database_error(e));
+        }
+    };
+
+    let cleanup = Finally::new({
+        let database = database.clone();
+        let backend = backend.clone();
+        let remote_file = remote_file.clone();
+        let part_id = insert_result.last_insert_id;
+
+        async move {
+            if let Err(e) = backend.delete_file_db(&remote_file).await
+                && !e.is_storage_not_found()
+            {
+                tracing::warn!("Failed to clean up upload session part object: {}", e);
+            }
+
+            if let Err(e) = UploadSessionPart::delete(upload_session_part::ActiveModel {
+                id: Set(part_id),
+                ..Default::default()
+            })
+            .exec(&database)
+            .await
+            {
+                tracing::warn!("Failed to clean up upload session part row: {}", e);
+            }
+        }
+    });
+
+    let stream = body
+        .into_data_stream()
+        .map(|r| r.map_err(|e| io::Error::other(e.to_string())));
+    let mut reader = StreamReader::new(stream);
+    backend.upload_file(key, &mut reader).await?;
+
+    let session = load_session(database, session_id).await?;
+    if session.state != UploadSessionState::Uploading.as_str() || Utc::now() > session.expires_at {
+        return Err(ErrorKind::RequestError(anyhow!(
+            "Upload session is no longer accepting parts"
+        ))
+        .into());
+    }
+
+    let update = UploadSessionPart::update_many()
+        .col_expr(
+            upload_session_part::Column::State,
+            Expr::value(UploadSessionPartState::Valid.as_str()),
+        )
+        .filter(upload_session_part::Column::Id.eq(insert_result.last_insert_id))
+        .filter(upload_session_part::Column::State.eq(UploadSessionPartState::Pending.as_str()))
+        .exec(database)
+        .await
+        .map_err(ServerError::database_error)?;
+    if update.rows_affected != 1 {
+        return Err(ErrorKind::RequestError(anyhow!("Upload session part was removed")).into());
+    }
+
+    let now = Utc::now();
+    let session_update = UploadSession::update_many()
+        .col_expr(upload_session::Column::UpdatedAt, Expr::value(now))
+        .filter(upload_session::Column::Id.eq(session.id.clone()))
+        .filter(upload_session::Column::State.eq(UploadSessionState::Uploading.as_str()))
+        .filter(upload_session::Column::ExpiresAt.gt(now))
+        .exec(database)
+        .await
+        .map_err(ServerError::database_error)?;
+    if session_update.rows_affected != 1 {
+        return Err(ErrorKind::RequestError(anyhow!(
+            "Upload session is no longer accepting parts"
+        ))
+        .into());
+    }
+
+    cleanup.cancel();
+
+    Ok(())
+}
+
+/// Finalizes a chunked transport upload session.
+#[instrument(skip_all, fields(session_id = %session_id))]
+pub(crate) async fn finalize_upload_session(
+    Extension(state): Extension<State>,
+    Extension(req_state): Extension<RequestState>,
+    Path(session_id): Path<Uuid>,
+) -> ServerResult<Json<FinalizeUploadSessionResponse>> {
+    let database = state.database().await?;
+    let session = load_session(database, session_id).await?;
+    let upload_info = parse_upload_info(&session)?;
+    req_state
+        .auth
+        .auth_cache(database, &upload_info.cache, |_, permission| {
+            permission.require_push()?;
+            Ok(())
+        })
+        .await?;
+
+    if session.state == UploadSessionState::Completed.as_str() {
+        let result_json = session.result.ok_or(ErrorKind::InternalServerError)?;
+        let result = serde_json::from_str(&result_json).map_err(ServerError::database_error)?;
+        return Ok(Json(FinalizeUploadSessionResponse::Completed { result }));
+    }
+    if session.state == UploadSessionState::Failed.as_str() {
+        return Ok(Json(FinalizeUploadSessionResponse::Failed {
+            message: "Upload session finalization failed".to_string(),
+        }));
+    }
+
+    let finalizing_is_stale = session.state == UploadSessionState::Finalizing.as_str()
+        && session.updated_at < stale_before(UPLOAD_SESSION_FINALIZE_STALE_AFTER)?;
+    if session.state == UploadSessionState::Finalizing.as_str() && !finalizing_is_stale {
+        return Ok(Json(FinalizeUploadSessionResponse::Pending));
+    }
+    if session.state != UploadSessionState::Uploading.as_str() && !finalizing_is_stale {
+        return Err(ErrorKind::RequestError(anyhow!("Upload session cannot be finalized")).into());
+    }
+
+    if session.state == UploadSessionState::Uploading.as_str() {
+        let expected_parts =
+            u64::try_from(session.expected_parts).map_err(ServerError::request_error)?;
+        let uploaded_parts = UploadSessionPart::find()
+            .filter(upload_session_part::Column::SessionId.eq(session.id.clone()))
+            .filter(upload_session_part::Column::State.eq(UploadSessionPartState::Valid.as_str()))
+            .count(database)
+            .await
+            .map_err(ServerError::database_error)?;
+
+        if uploaded_parts != expected_parts {
+            return Ok(Json(FinalizeUploadSessionResponse::Pending));
+        }
+    }
+
+    let update = UploadSession::update_many()
+        .col_expr(
+            upload_session::Column::State,
+            Expr::value(UploadSessionState::Finalizing.as_str()),
+        )
+        .col_expr(upload_session::Column::UpdatedAt, Expr::value(Utc::now()))
+        .filter(upload_session::Column::Id.eq(session.id.clone()));
+
+    let update = if finalizing_is_stale {
+        update
+            .filter(upload_session::Column::State.eq(UploadSessionState::Finalizing.as_str()))
+            .filter(
+                upload_session::Column::UpdatedAt
+                    .lt(stale_before(UPLOAD_SESSION_FINALIZE_STALE_AFTER)?),
+            )
+    } else {
+        update.filter(upload_session::Column::State.eq(session.state.clone()))
+    };
+
+    let updated = update
+        .exec(database)
+        .await
+        .map_err(ServerError::database_error)?;
+    if updated.rows_affected != 1 {
+        return Ok(Json(FinalizeUploadSessionResponse::Pending));
+    }
+
+    spawn_finalize_upload_session(state.clone(), req_state, session, upload_info);
+
+    Ok(Json(FinalizeUploadSessionResponse::Pending))
+}
+
+fn spawn_finalize_upload_session(
+    state: State,
+    req_state: RequestState,
+    session: upload_session::Model,
+    upload_info: UploadPathNarInfo,
+) {
+    spawn(async move {
+        let session_id = session.id.clone();
+        let finalize =
+            finalize_upload_session_inner(state.clone(), req_state, session, upload_info);
+        tokio::pin!(finalize);
+        let mut heartbeat = time::interval(UPLOAD_SESSION_FINALIZE_HEARTBEAT);
+
+        let result = loop {
+            tokio::select! {
+                result = &mut finalize => break result,
+                _ = heartbeat.tick() => {
+                    heartbeat_upload_session_finalization(&state, &session_id).await;
+                }
+            }
+        };
+
+        if let Err(e) = result {
+            tracing::warn!("Failed to finalize upload session {}: {}", session_id, e);
+            if let Ok(database) = state.database().await {
+                let _ = UploadSession::update_many()
+                    .col_expr(
+                        upload_session::Column::State,
+                        Expr::value(UploadSessionState::Failed.as_str()),
+                    )
+                    .col_expr(upload_session::Column::UpdatedAt, Expr::value(Utc::now()))
+                    .filter(upload_session::Column::Id.eq(session_id))
+                    .filter(
+                        upload_session::Column::State.eq(UploadSessionState::Finalizing.as_str()),
+                    )
+                    .exec(database)
+                    .await;
+            }
+        }
+    });
+}
+
+async fn heartbeat_upload_session_finalization(state: &State, session_id: &str) {
+    if let Ok(database) = state.database().await
+        && let Err(e) = UploadSession::update_many()
+            .col_expr(upload_session::Column::UpdatedAt, Expr::value(Utc::now()))
+            .filter(upload_session::Column::Id.eq(session_id.to_string()))
+            .filter(upload_session::Column::State.eq(UploadSessionState::Finalizing.as_str()))
+            .exec(database)
+            .await
+    {
+        tracing::warn!(
+            "Failed to heartbeat upload session finalization {}: {}",
+            session_id,
+            e
+        );
+    }
+}
+
+async fn finalize_upload_session_inner(
+    state: State,
+    req_state: RequestState,
+    session: upload_session::Model,
+    upload_info: UploadPathNarInfo,
+) -> ServerResult<UploadPathResult> {
+    let database = state.database().await?;
+    let parts = UploadSessionPart::find()
+        .filter(upload_session_part::Column::SessionId.eq(session.id.clone()))
+        .filter(upload_session_part::Column::State.eq(UploadSessionPartState::Valid.as_str()))
+        .order_by_asc(upload_session_part::Column::Seq)
+        .all(database)
+        .await
+        .map_err(ServerError::database_error)?;
+
+    let expected_parts =
+        usize::try_from(session.expected_parts).map_err(ServerError::request_error)?;
+    if parts.len() != expected_parts {
+        return Err(ErrorKind::RequestError(anyhow!("Upload session is missing parts")).into());
+    }
+
+    for (idx, part) in parts.iter().enumerate() {
+        if part.seq != idx as i32 {
+            return Err(ErrorKind::RequestError(anyhow!("Upload session parts have a gap")).into());
+        }
+    }
+
+    let remote_files = parts
+        .iter()
+        .map(|p| {
+            serde_json::from_str::<RemoteFile>(&p.remote_file).map_err(ServerError::database_error)
+        })
+        .collect::<ServerResult<Vec<_>>>()?;
+    let stream = Box::pin(stream_remote_files(state.clone(), remote_files));
+    let stream = StreamReader::new(stream);
+
+    let Json(result) = ingest_upload_path(state.clone(), req_state, upload_info, stream).await?;
+    let updated = UploadSession::update_many()
+        .col_expr(
+            upload_session::Column::State,
+            Expr::value(UploadSessionState::Completed.as_str()),
+        )
+        .col_expr(upload_session::Column::UpdatedAt, Expr::value(Utc::now()))
+        .col_expr(
+            upload_session::Column::Result,
+            Expr::value(Some(
+                serde_json::to_string(&result).map_err(ServerError::request_error)?,
+            )),
+        )
+        .filter(upload_session::Column::Id.eq(session.id.clone()))
+        .filter(upload_session::Column::State.eq(UploadSessionState::Finalizing.as_str()))
+        .exec(database)
+        .await
+        .map_err(ServerError::database_error)?;
+    if updated.rows_affected != 1 {
+        return Err(
+            ErrorKind::RequestError(anyhow!("Upload session finalization was cancelled")).into(),
+        );
+    }
+
+    if let Err(e) = crate::gc::delete_upload_session_parts(&state, &session.id).await {
+        tracing::warn!(
+            "Failed to clean up completed upload session parts for session {}: {}",
+            session.id,
+            e
+        );
+    }
+
+    Ok(result)
+}
+
+/// Aborts a chunked transport upload session.
+#[instrument(skip_all, fields(session_id = %session_id))]
+pub(crate) async fn abort_upload_session(
+    Extension(state): Extension<State>,
+    Extension(req_state): Extension<RequestState>,
+    Path(session_id): Path<Uuid>,
+) -> ServerResult<()> {
+    let database = state.database().await?;
+    let session = load_session(database, session_id).await?;
+    let upload_info = parse_upload_info(&session)?;
+    req_state
+        .auth
+        .auth_cache(database, &upload_info.cache, |_, permission| {
+            permission.require_push()?;
+            Ok(())
+        })
+        .await?;
+
+    if session.state == UploadSessionState::Aborted.as_str() {
+        return Ok(());
+    }
+    if session.state == UploadSessionState::Finalizing.as_str()
+        || session.state == UploadSessionState::Completed.as_str()
+    {
+        return Err(ErrorKind::RequestError(anyhow!("Upload session cannot be aborted")).into());
+    }
+
+    let updated = UploadSession::update_many()
+        .col_expr(
+            upload_session::Column::State,
+            Expr::value(UploadSessionState::Aborted.as_str()),
+        )
+        .col_expr(upload_session::Column::UpdatedAt, Expr::value(Utc::now()))
+        .filter(upload_session::Column::Id.eq(session.id.clone()))
+        .filter(upload_session::Column::State.is_in([
+            UploadSessionState::Uploading.as_str(),
+            UploadSessionState::Failed.as_str(),
+        ]))
+        .exec(database)
+        .await
+        .map_err(ServerError::database_error)?;
+    if updated.rows_affected != 1 {
+        return Err(ErrorKind::RequestError(anyhow!("Upload session cannot be aborted")).into());
+    }
+
+    if let Err(e) = crate::gc::delete_upload_session_parts(&state, &session.id).await {
+        tracing::warn!(
+            "Failed to clean up aborted upload session parts for session {}: {}",
+            session.id,
+            e
+        );
+    }
+    Ok(())
 }
 
 /// Uploads a path when there is already a matching NAR in the global cache.
@@ -256,6 +810,58 @@ async fn upload_path_new(
     }
 }
 
+async fn load_session(
+    database: &DatabaseConnection,
+    session_id: Uuid,
+) -> ServerResult<upload_session::Model> {
+    UploadSession::find_by_id(session_id.to_string())
+        .one(database)
+        .await
+        .map_err(ServerError::database_error)?
+        .ok_or(ErrorKind::NotFound.into())
+}
+
+fn parse_upload_info(session: &upload_session::Model) -> ServerResult<UploadPathNarInfo> {
+    serde_json::from_str(&session.upload_info).map_err(ServerError::database_error)
+}
+
+fn stale_before(duration: Duration) -> ServerResult<chrono::DateTime<Utc>> {
+    Ok(Utc::now() - chrono::Duration::from_std(duration).map_err(ServerError::request_error)?)
+}
+
+fn stream_remote_files(
+    state: State,
+    remote_files: Vec<RemoteFile>,
+) -> impl futures::Stream<Item = Result<Bytes, io::Error>> {
+    try_stream! {
+        let backend = state
+            .storage()
+            .await
+            .map_err(|e| io::Error::other(e.to_string()))?
+            .clone();
+
+        for remote_file in remote_files {
+            let download = backend
+                .download_file_db(&remote_file, true)
+                .await
+                .map_err(|e| io::Error::other(e.to_string()))?;
+            let reader: Box<dyn AsyncRead + Unpin + Send> = match download {
+                Download::AsyncRead(reader) => reader,
+                Download::Url(_) => {
+                    Err(io::Error::other(
+                        "storage backend returned URL for upload session part",
+                    ))?
+                }
+            };
+
+            let mut stream = ReaderStream::new(reader);
+            while let Some(chunk) = stream.next().await {
+                yield chunk?;
+            }
+        }
+    }
+}
+
 /// Uploads a path when there is no matching NAR in the global cache (chunked).
 async fn upload_path_new_chunked(
     username: Option<String>,
@@ -322,11 +928,17 @@ async fn upload_path_new_chunked(
     );
 
     let upload_chunk_limit = Arc::new(Semaphore::new(CONCURRENT_CHUNK_UPLOADS));
-    let mut futures = Vec::new();
+    let mut futures: Vec<JoinHandle<ServerResult<UploadChunkResult>>> = Vec::new();
 
     let mut chunk_idx = 0;
     while let Some(bytes) = chunks.next().await {
-        let bytes = bytes.map_err(ServerError::request_error)?;
+        let bytes = match bytes {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                abort_upload_chunk_tasks(futures).await;
+                return Err(ServerError::request_error(e));
+            }
+        };
         let data = ChunkData::Bytes(bytes);
 
         // Wait for a permit before spawning
@@ -375,6 +987,7 @@ async fn upload_path_new_chunked(
     let nar_hash = Hash::Sha256((&nar_hash[..]).try_into().unwrap());
 
     if nar_hash != upload_info.nar_hash || *nar_size != upload_info.nar_size {
+        abort_upload_chunk_tasks(futures).await;
         return Err(ErrorKind::RequestError(anyhow!("Bad NAR Hash or Size")).into());
     }
 
@@ -441,6 +1054,14 @@ async fn upload_path_new_chunked(
         // Currently, frac_deduplicated is computed from size before compression
         frac_deduplicated: Some(deduplicated_size as f64 / *nar_size as f64),
     }))
+}
+
+async fn abort_upload_chunk_tasks(futures: Vec<JoinHandle<ServerResult<UploadChunkResult>>>) {
+    for future in &futures {
+        future.abort();
+    }
+
+    let _ = join_all(futures).await;
 }
 
 /// Uploads a path when there is no matching NAR in the global cache (unchunked).

--- a/server/src/config-template.toml
+++ b/server/src/config-template.toml
@@ -82,6 +82,13 @@ path = "%storage_path%"
 #  access_key_id = ""
 #  secret_access_key = ""
 
+# Upload configuration
+[upload]
+# The maximum size of each chunked transport upload part, in bytes.
+#
+# If unset, clients will use the non-chunked upload path by default.
+#max-chunk-size = 33554432 # 32 MiB
+
 # Data chunking
 #
 # Warning: If you change any of the values here, it will be

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -113,6 +113,10 @@ pub struct Config {
     /// Storage.
     pub storage: StorageConfig,
 
+    /// Upload.
+    #[serde(default = "Default::default")]
+    pub upload: UploadConfig,
+
     /// Data chunking.
     pub chunking: ChunkingConfig,
 
@@ -227,6 +231,17 @@ pub enum StorageConfig {
     /// S3 storage.
     #[serde(rename = "s3")]
     S3(S3StorageConfig),
+}
+
+/// Upload configuration.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct UploadConfig {
+    /// Maximum size of each chunked transport upload part, in bytes.
+    ///
+    /// If unconfigured, clients will use the non-chunked upload path by default.
+    #[serde(rename = "max-chunk-size")]
+    #[serde(default = "Default::default")]
+    pub max_chunk_size: Option<usize>,
 }
 
 /// Data chunking.

--- a/server/src/database/entity/mod.rs
+++ b/server/src/database/entity/mod.rs
@@ -7,6 +7,8 @@ pub mod chunk;
 pub mod chunkref;
 pub mod nar;
 pub mod object;
+pub mod upload_session;
+pub mod upload_session_part;
 
 use sea_orm::entity::Value;
 use sea_orm::sea_query::{ArrayType, ColumnType, ValueType, ValueTypeErr, table::StringLen};

--- a/server/src/database/entity/upload_session.rs
+++ b/server/src/database/entity/upload_session.rs
@@ -1,0 +1,84 @@
+//! A chunked transport upload session.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum UploadSessionState {
+    Uploading,
+    Finalizing,
+    Reaping,
+    Completed,
+    Aborted,
+    Failed,
+}
+
+impl UploadSessionState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Uploading => "uploading",
+            Self::Finalizing => "finalizing",
+            Self::Reaping => "reaping",
+            Self::Completed => "completed",
+            Self::Aborted => "aborted",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// A chunked transport upload session.
+#[derive(Debug, Clone, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "upload_session")]
+pub struct Model {
+    /// UUID of the upload session.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+
+    /// ID of the cache this upload targets.
+    #[sea_orm(indexed)]
+    pub cache_id: i64,
+
+    /// Serialized `UploadPathNarInfo`.
+    pub upload_info: String,
+
+    /// Number of expected transport parts.
+    pub expected_parts: i32,
+
+    /// Session state.
+    pub state: String,
+
+    /// User that created the session.
+    pub created_by: Option<String>,
+
+    /// Timestamp when the session is created.
+    pub created_at: ChronoDateTimeUtc,
+
+    /// Timestamp when the session is last updated.
+    pub updated_at: ChronoDateTimeUtc,
+
+    /// Timestamp after which the session can be garbage-collected.
+    pub expires_at: ChronoDateTimeUtc,
+
+    /// Serialized `UploadPathResult` when the upload is completed.
+    pub result: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(has_many = "super::upload_session_part::Entity")]
+    UploadSessionPart,
+
+    #[sea_orm(
+        belongs_to = "super::cache::Entity",
+        from = "Column::CacheId",
+        to = "super::cache::Column::Id"
+    )]
+    Cache,
+}
+
+impl Related<super::cache::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Cache.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/server/src/database/entity/upload_session_part.rs
+++ b/server/src/database/entity/upload_session_part.rs
@@ -1,0 +1,61 @@
+//! A chunked transport upload session part.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum UploadSessionPartState {
+    Pending,
+    Valid,
+}
+
+impl UploadSessionPartState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Valid => "valid",
+        }
+    }
+}
+
+/// A chunked transport upload session part.
+#[derive(Debug, Clone, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "upload_session_part")]
+pub struct Model {
+    /// Unique numeric ID of the part row.
+    #[sea_orm(primary_key)]
+    pub id: i64,
+
+    /// UUID of the upload session.
+    #[sea_orm(indexed)]
+    pub session_id: String,
+
+    /// Zero-indexed transport part sequence number.
+    pub seq: i32,
+
+    /// Upload state of the transport part.
+    pub state: String,
+
+    /// Serialized `RemoteFile` backing this transport part.
+    pub remote_file: String,
+
+    /// Timestamp when the part is created.
+    pub created_at: ChronoDateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::upload_session::Entity",
+        from = "Column::SessionId",
+        to = "super::upload_session::Column::Id"
+    )]
+    UploadSession,
+}
+
+impl Related<super::upload_session::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::UploadSession.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/server/src/database/migration/m20260531_000001_add_upload_session_tables.rs
+++ b/server/src/database/migration/m20260531_000001_add_upload_session_tables.rs
@@ -1,0 +1,172 @@
+use sea_orm_migration::prelude::*;
+
+use crate::database::entity::upload_session::UploadSessionState;
+use crate::database::entity::upload_session_part::UploadSessionPartState;
+use crate::database::entity::{cache, upload_session, upload_session_part};
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260531_000001_add_upload_session_tables"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(upload_session::Entity)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(upload_session::Column::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(upload_session::Column::CacheId)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(upload_session::Column::UploadInfo)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(upload_session::Column::ExpectedParts)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(upload_session::Column::State)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(upload_session::Column::CreatedBy).string())
+                    .col(
+                        ColumnDef::new(upload_session::Column::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(upload_session::Column::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(upload_session::Column::ExpiresAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(upload_session::Column::Result).text())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk-upload-session-cache")
+                            .from(upload_session::Entity, upload_session::Column::CacheId)
+                            .to(cache::Entity, cache::Column::Id)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .check(upload_session_state_check())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(upload_session_part::Entity)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(upload_session_part::Column::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(upload_session_part::Column::SessionId)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(upload_session_part::Column::Seq)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(upload_session_part::Column::State)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(upload_session_part::Column::RemoteFile)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(upload_session_part::Column::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk-upload-session-part-session")
+                            .from(
+                                upload_session_part::Entity,
+                                upload_session_part::Column::SessionId,
+                            )
+                            .to(upload_session::Entity, upload_session::Column::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .check(upload_session_part_state_check())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-upload-session-cache-id")
+                    .table(upload_session::Entity)
+                    .col(upload_session::Column::CacheId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-upload-session-part-session-seq")
+                    .table(upload_session_part::Entity)
+                    .col(upload_session_part::Column::SessionId)
+                    .col(upload_session_part::Column::Seq)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+fn upload_session_state_check() -> SimpleExpr {
+    Expr::col(upload_session::Column::State).is_in([
+        UploadSessionState::Uploading.as_str(),
+        UploadSessionState::Finalizing.as_str(),
+        UploadSessionState::Reaping.as_str(),
+        UploadSessionState::Completed.as_str(),
+        UploadSessionState::Aborted.as_str(),
+        UploadSessionState::Failed.as_str(),
+    ])
+}
+
+fn upload_session_part_state_check() -> SimpleExpr {
+    Expr::col(upload_session_part::Column::State).is_in([
+        UploadSessionPartState::Pending.as_str(),
+        UploadSessionPartState::Valid.as_str(),
+    ])
+}

--- a/server/src/database/migration/mod.rs
+++ b/server/src/database/migration/mod.rs
@@ -15,6 +15,7 @@ mod m20230112_000004_migrate_nar_remote_files_to_chunks;
 mod m20230112_000005_drop_old_nar_columns;
 mod m20230112_000006_add_nar_completeness_hint;
 mod m20260508_000001_add_chunk_state_holders_index;
+mod m20260531_000001_add_upload_session_tables;
 mod m20260611_000001_add_nar_state_holders_index;
 mod m20260624_000001_remove_chunk_recovery;
 
@@ -38,6 +39,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230112_000006_add_nar_completeness_hint::Migration),
             Box::new(m20260508_000001_add_chunk_state_holders_index::Migration),
             Box::new(m20260611_000001_add_nar_state_holders_index::Migration),
+            Box::new(m20260531_000001_add_upload_session_tables::Migration),
             Box::new(m20260624_000001_remove_chunk_recovery::Migration),
         ]
     }

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -2,6 +2,7 @@
 
 use std::error::Error as StdError;
 use std::fmt;
+use std::io;
 
 use anyhow::Error as AnyError;
 use axum::Json;
@@ -94,6 +95,15 @@ impl ServerError {
 
     pub fn request_error(error: impl StdError + Send + Sync + 'static) -> Self {
         ErrorKind::RequestError(AnyError::new(error)).into()
+    }
+
+    pub fn is_storage_not_found(&self) -> bool {
+        match &self.kind {
+            ErrorKind::StorageError(error) => error
+                .downcast_ref::<io::Error>()
+                .is_some_and(|e| e.kind() == io::ErrorKind::NotFound),
+            _ => false,
+        }
     }
 
     pub fn set_discovery_permission(&mut self, perm: bool) {

--- a/server/src/gc.rs
+++ b/server/src/gc.rs
@@ -8,8 +8,8 @@ use chrono::{Duration as ChronoDuration, Utc};
 use futures::future::join_all;
 use sea_orm::entity::prelude::*;
 use sea_orm::query::QuerySelect;
-use sea_orm::sea_query::{LockBehavior, LockType, Query};
-use sea_orm::{ConnectionTrait, ExprTrait, FromQueryResult};
+use sea_orm::sea_query::{Expr, LockBehavior, LockType, Query};
+use sea_orm::{ConnectionTrait, ExprTrait, FromQueryResult, TransactionTrait};
 use tokio::sync::Semaphore;
 use tokio::time;
 use tokio_util::sync::CancellationToken;
@@ -22,7 +22,13 @@ use crate::database::entity::chunk::{self, ChunkState, Entity as Chunk};
 use crate::database::entity::chunkref::{self, Entity as ChunkRef};
 use crate::database::entity::nar::{self, Entity as Nar, NarState};
 use crate::database::entity::object::{self, Entity as Object};
+use crate::database::entity::upload_session::{self, Entity as UploadSession, UploadSessionState};
+use crate::database::entity::upload_session_part::{self, Entity as UploadSessionPart};
+use crate::storage::RemoteFile;
 use crate::storage::StorageBackend;
+
+const UPLOAD_SESSION_ACTIVE_GRACE: Duration = Duration::from_secs(30 * 60);
+const UPLOAD_SESSION_FINALIZE_STALE_AFTER: Duration = Duration::from_secs(2 * 60);
 
 #[derive(Debug, FromQueryResult)]
 struct CacheIdAndRetentionPeriod {
@@ -71,6 +77,14 @@ pub async fn run_garbage_collection_once(config: Config) -> Result<()> {
 
     let state = StateInner::new(config).await;
     run_time_based_garbage_collection(&state).await?;
+    let (deleted_sessions, deleted_parts) = reap_expired_upload_sessions(&state).await?;
+    if deleted_sessions != 0 || deleted_parts != 0 {
+        tracing::info!(
+            "Deleted {} expired upload sessions and {} uploaded parts",
+            deleted_sessions,
+            deleted_parts
+        );
+    }
     run_reap_orphan_nars(&state).await?;
     run_reap_orphan_chunks(&state).await?;
 
@@ -136,6 +150,198 @@ async fn run_time_based_garbage_collection(state: &State) -> Result<()> {
     tracing::info!("Deleted {} objects in total", objects_deleted);
 
     Ok(())
+}
+
+/// Reaps expired chunked transport upload sessions.
+///
+/// The session row is only deleted after every referenced part object is
+/// deleted, so failed storage cleanup leaves the DB references available for a
+/// future retry.
+#[instrument(skip_all)]
+pub(crate) async fn reap_expired_upload_sessions(state: &State) -> Result<(u64, u64)> {
+    let db = state.database().await?;
+    let now = Utc::now();
+    let active_after = now - ChronoDuration::from_std(UPLOAD_SESSION_ACTIVE_GRACE)?;
+    let stale_finalizing_before =
+        now - ChronoDuration::from_std(UPLOAD_SESSION_FINALIZE_STALE_AFTER)?;
+
+    let sessions = UploadSession::find()
+        .filter(upload_session::Column::ExpiresAt.lt(now))
+        .filter(upload_session::Column::UpdatedAt.lt(active_after))
+        .filter(
+            upload_session::Column::State
+                .ne(UploadSessionState::Finalizing.as_str())
+                .or(upload_session::Column::UpdatedAt.lt(stale_finalizing_before)),
+        )
+        .all(db)
+        .await?;
+
+    delete_upload_sessions(state, sessions).await
+}
+
+/// Deletes all upload sessions for a cache after their temporary part objects
+/// have been cleaned up.
+pub(crate) async fn delete_upload_sessions_for_cache(
+    state: &State,
+    cache_id: i64,
+) -> Result<(u64, u64)> {
+    let db = state.database().await?;
+    let txn = db.begin().await?;
+
+    let sessions = UploadSession::find()
+        .filter(upload_session::Column::CacheId.eq(cache_id))
+        .all(&txn)
+        .await?;
+
+    for session in &sessions {
+        if !claim_upload_session_for_cleanup(&txn, session).await? {
+            txn.rollback().await?;
+            return Err(anyhow!(
+                "Cannot delete upload session {} while it is active",
+                session.id
+            ));
+        }
+    }
+
+    txn.commit().await?;
+
+    delete_claimed_upload_sessions(state, sessions).await
+}
+
+async fn delete_upload_sessions(
+    state: &State,
+    sessions: Vec<upload_session::Model>,
+) -> Result<(u64, u64)> {
+    if sessions.is_empty() {
+        return Ok((0, 0));
+    }
+
+    let db = state.database().await?;
+    let mut claimed_sessions = Vec::new();
+
+    for session in sessions {
+        if !claim_upload_session_for_cleanup(db, &session).await? {
+            continue;
+        }
+
+        claimed_sessions.push(session);
+    }
+
+    delete_claimed_upload_sessions(state, claimed_sessions).await
+}
+
+async fn delete_claimed_upload_sessions(
+    state: &State,
+    sessions: Vec<upload_session::Model>,
+) -> Result<(u64, u64)> {
+    let db = state.database().await?;
+
+    if sessions.is_empty() {
+        return Ok((0, 0));
+    }
+
+    let mut deleted_sessions = 0;
+    let mut deleted_parts = 0;
+
+    for session in sessions {
+        let deleted_part_count = match delete_upload_session_parts(state, &session.id).await {
+            Ok(deleted_part_count) => deleted_part_count,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to delete upload session parts for session {}: {}",
+                    session.id,
+                    e
+                );
+                continue;
+            }
+        };
+
+        let deletion = UploadSession::delete_many()
+            .filter(upload_session::Column::Id.eq(session.id))
+            .filter(upload_session::Column::State.eq(UploadSessionState::Reaping.as_str()))
+            .exec(db)
+            .await?;
+
+        deleted_sessions += deletion.rows_affected;
+        deleted_parts += deleted_part_count;
+    }
+
+    Ok((deleted_sessions, deleted_parts))
+}
+
+async fn claim_upload_session_for_cleanup<C>(
+    db: &C,
+    session: &upload_session::Model,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let update = UploadSession::update_many()
+        .col_expr(
+            upload_session::Column::State,
+            Expr::value(UploadSessionState::Reaping.as_str()),
+        )
+        .col_expr(upload_session::Column::UpdatedAt, Expr::value(Utc::now()))
+        .filter(upload_session::Column::Id.eq(session.id.clone()));
+
+    let update = if session.state == UploadSessionState::Finalizing.as_str() {
+        update
+            .filter(upload_session::Column::State.eq(UploadSessionState::Finalizing.as_str()))
+            .filter(
+                upload_session::Column::UpdatedAt.lt(
+                    Utc::now() - ChronoDuration::from_std(UPLOAD_SESSION_FINALIZE_STALE_AFTER)?,
+                ),
+            )
+    } else {
+        update.filter(upload_session::Column::State.is_in([
+            UploadSessionState::Uploading.as_str(),
+            UploadSessionState::Reaping.as_str(),
+            UploadSessionState::Completed.as_str(),
+            UploadSessionState::Aborted.as_str(),
+            UploadSessionState::Failed.as_str(),
+        ]))
+    };
+
+    let result = update.exec(db).await?;
+    Ok(result.rows_affected == 1)
+}
+
+/// Deletes all uploaded part objects for a session and then deletes their DB rows.
+///
+/// Missing storage objects are treated as already deleted so that sessions whose
+/// parts were cleaned up by finalize or abort can still be reaped later.
+pub(crate) async fn delete_upload_session_parts(state: &State, session_id: &str) -> Result<u64> {
+    let db = state.database().await?;
+    let storage = state.storage().await?;
+
+    let parts = UploadSessionPart::find()
+        .filter(upload_session_part::Column::SessionId.eq(session_id.to_string()))
+        .all(db)
+        .await?;
+    let remote_files = parts
+        .iter()
+        .map(|part| serde_json::from_str::<RemoteFile>(&part.remote_file))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    for remote_file in &remote_files {
+        if let Err(e) = storage.delete_file_db(remote_file).await {
+            if e.is_storage_not_found() {
+                tracing::debug!(
+                    "Upload session part for session {} was already deleted",
+                    session_id
+                );
+                continue;
+            }
+            return Err(e.into());
+        }
+    }
+
+    let deletion = UploadSessionPart::delete_many()
+        .filter(upload_session_part::Column::SessionId.eq(session_id.to_string()))
+        .exec(db)
+        .await?;
+
+    Ok(deletion.rows_affected)
 }
 
 #[instrument(skip_all)]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;

--- a/server/src/storage/local.rs
+++ b/server/src/storage/local.rs
@@ -122,6 +122,36 @@ impl LocalBackend {
         let level2 = &p[0..2];
         self.config.path.join(level1).join(level2).join(p)
     }
+
+    async fn remove_empty_parent_dirs(&self, path: &Path) {
+        let mut current = path.parent();
+
+        while let Some(dir) = current {
+            if dir == self.config.path {
+                break;
+            }
+
+            match fs::remove_dir(dir).await {
+                Ok(()) => {
+                    current = dir.parent();
+                }
+                Err(e)
+                    if e.kind() == io::ErrorKind::NotFound
+                        || e.kind() == io::ErrorKind::DirectoryNotEmpty =>
+                {
+                    break;
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "Failed to remove empty storage directory {}: {}",
+                        dir.display(),
+                        e
+                    );
+                    break;
+                }
+            }
+        }
+    }
 }
 
 impl StorageBackend for LocalBackend {
@@ -156,9 +186,11 @@ impl StorageBackend for LocalBackend {
     }
 
     async fn delete_file(&self, name: String) -> ServerResult<()> {
-        fs::remove_file(self.get_path(&name))
+        let path = self.get_path(&name);
+        fs::remove_file(&path)
             .await
             .map_err(ServerError::storage_error)?;
+        self.remove_empty_parent_dirs(&path).await;
 
         Ok(())
     }
@@ -173,9 +205,11 @@ impl StorageBackend for LocalBackend {
             .into());
         };
 
-        fs::remove_file(self.get_path(&file.name))
+        let path = self.get_path(&file.name);
+        fs::remove_file(&path)
             .await
             .map_err(ServerError::storage_error)?;
+        self.remove_empty_parent_dirs(&path).await;
 
         Ok(())
     }


### PR DESCRIPTION
Add chunked transport upload sessions for pushing large NARs. Clients can upload a NAR as sequential transport parts, and the server stores those parts in temporary upload sessions before ingesting the reconstructed NAR.

Expose chunked upload capability through cache-config when the server configures upload.max-chunk-size. Clients use non-chunked uploads when the capability is absent, use the advertised max chunk size by default when present, and reject explicit --chunk-size values that exceed the server limit.

Finalize upload sessions asynchronously and let clients poll for completion. The server waits until all expected parts are present before starting finalization, then validates part ordering and size, ingests the reconstructed NAR, records the result, and cleans up temporary session parts.

Add upload session database entities, migrations, API routes, and garbage collection for stale session data.

Closes https://github.com/zhaofengli/attic/issues/287.