### PR TITLE
add index on chunk table to avoid GC tablescan

### DIFF
--- a/server/src/database/migration/m20260508_000001_add_chunk_state_holders_index.rs
+++ b/server/src/database/migration/m20260508_000001_add_chunk_state_holders_index.rs
@@ -1,0 +1,38 @@
+use sea_orm_migration::prelude::*;
+
+use crate::database::entity::chunk::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260508_000001_add_chunk_state_holders_index"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-chunk-state-holders")
+                    .table(Entity)
+                    .col(Column::State)
+                    .col(Column::HoldersCount)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-chunk-state-holders")
+                    .table(Entity)
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/server/src/database/migration/m20260611_000001_add_nar_state_holders_index.rs
+++ b/server/src/database/migration/m20260611_000001_add_nar_state_holders_index.rs
@@ -1,0 +1,38 @@
+use sea_orm_migration::prelude::*;
+
+use crate::database::entity::nar::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260611_000001_add_nar_state_holders_index"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-nar-state-holders")
+                    .table(Entity)
+                    .col(Column::State)
+                    .col(Column::HoldersCount)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-nar-state-holders")
+                    .table(Entity)
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/server/src/database/migration/mod.rs
+++ b/server/src/database/migration/mod.rs
@@ -14,6 +14,7 @@ mod m20230112_000003_add_nar_num_chunks;
 mod m20230112_000004_migrate_nar_remote_files_to_chunks;
 mod m20230112_000005_drop_old_nar_columns;
 mod m20230112_000006_add_nar_completeness_hint;
+mod m20260508_000001_add_chunk_state_holders_index;
 
 pub struct Migrator;
 
@@ -33,6 +34,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230112_000004_migrate_nar_remote_files_to_chunks::Migration),
             Box::new(m20230112_000005_drop_old_nar_columns::Migration),
             Box::new(m20230112_000006_add_nar_completeness_hint::Migration),
+            Box::new(m20260508_000001_add_chunk_state_holders_index::Migration),
         ]
     }
 }

--- a/server/src/database/migration/mod.rs
+++ b/server/src/database/migration/mod.rs
@@ -15,6 +15,7 @@ mod m20230112_000004_migrate_nar_remote_files_to_chunks;
 mod m20230112_000005_drop_old_nar_columns;
 mod m20230112_000006_add_nar_completeness_hint;
 mod m20260508_000001_add_chunk_state_holders_index;
+mod m20260611_000001_add_nar_state_holders_index;
 
 pub struct Migrator;
 
@@ -35,6 +36,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230112_000005_drop_old_nar_columns::Migration),
             Box::new(m20230112_000006_add_nar_completeness_hint::Migration),
             Box::new(m20260508_000001_add_chunk_state_holders_index::Migration),
+            Box::new(m20260611_000001_add_nar_state_holders_index::Migration),
         ]
     }
 }


### PR DESCRIPTION
Adds composite indexes on `chunk(state, holders_count)` and `nar(state, holders_count)` to avoid tablescans during GC.
Attic's GC runs these every 12hs: `run_reap_orphan_chunks` & `run_reap_orphan_nars`

      UPDATE chunk SET state = 'D' WHERE id IN (
           SELECT chunk.id FROM chunk
        LEFT JOIN chunkref ON chunkref.chunk_id = chunk.id
            WHERE chunk.state = 'V'         <- ** UNINDEXED **
              AND chunk.holders_count = 0   <- ** UNINDEXED **
              AND chunkref.id IS NULL)

Neither `state` nor `holders_count` is indexed.
In our setup with ~2.5M chunkrefs each sweep scanned the full table and locked it for ~5s per cycle.

Tested via `atticd --mode db-migrations`.

Probably related: #64, #66