### PR TITLE
server: add optional storage.public-endpoint for S3 presigned URLs

### DIFF
--- a/book/src/admin-guide/deployment/nixos.md
+++ b/book/src/admin-guide/deployment/nixos.md
@@ -79,6 +79,34 @@ You can import the module in one of two ways:
 After the new configuration is deployed, the Attic Server will be accessible on port 8080.
 It's highly recommended to place it behind a reverse proxy like [NGINX](https://nixos.wiki/wiki/Nginx) to provide HTTPS.
 
+### Using S3 Storage
+
+To use S3 (or an S3-compatible service), configure `services.atticd.settings.storage`:
+
+```nix
+{
+  services.atticd.settings.storage = {
+    type = "s3";
+    region = "us-east-1";
+    bucket = "attic";
+
+    # Internal endpoint used by atticd for uploads/reads/deletes.
+    endpoint = "http://s3.storage.svc.cluster.local:9000";
+
+    # Optional public endpoint used only for generated presigned
+    # download URLs returned to clients.
+    public-endpoint = "https://s3.example.com";
+
+    credentials = {
+      access_key_id = "...";
+      secret_access_key = "...";
+    };
+  };
+}
+```
+
+If `public-endpoint` is unset, Attic uses `endpoint` for presigned URLs too.
+
 ## Operations
 
 The NixOS module installs the `atticd-atticadm` wrapper which runs the `atticadm` command as the `atticd` user.

--- a/server/src/config-template.toml
+++ b/server/src/config-template.toml
@@ -74,6 +74,12 @@ path = "%storage_path%"
 # Set this if you are using an S3-compatible object storage (e.g., Minio).
 #endpoint = "https://xxx.r2.cloudflarestorage.com"
 
+# Public S3 endpoint for presigned download URLs
+#
+# If set, this is only used when generating presigned download URLs returned
+# to clients. Internal reads/writes/uploads/deletes still use `endpoint`.
+#public-endpoint = "https://s3.example.com"
+
 # Credentials
 #
 # If unset, the credentials are read from the `AWS_ACCESS_KEY_ID` and

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -28,6 +28,7 @@ const CHUNK_SIZE: usize = 8 * 1024 * 1024;
 #[derive(Debug)]
 pub struct S3Backend {
     client: Client,
+    public_download_client: Option<Client>,
     config: S3StorageConfig,
 }
 
@@ -44,6 +45,13 @@ pub struct S3StorageConfig {
     ///
     /// Set this if you are using an S3-compatible object storage (e.g., Minio).
     endpoint: Option<String>,
+
+    /// Public S3 endpoint for client-facing presigned download URLs.
+    ///
+    /// If set, this is only used for generating presigned download URLs.
+    /// Internal reads/writes still use `endpoint`.
+    #[serde(rename = "public-endpoint")]
+    public_endpoint: Option<String>,
 
     /// S3 credentials.
     ///
@@ -79,19 +87,35 @@ pub struct S3RemoteFile {
 
 impl S3Backend {
     pub async fn new(config: S3StorageConfig) -> ServerResult<Self> {
-        let s3_config = Self::config_builder(&config)
+        let s3_config = Self::config_builder(&config, None)
             .await?
             .region(Region::new(config.region.to_owned()))
             .retry_config(RetryConfig::adaptive())
             .build();
 
+        let public_download_client = if let Some(public_endpoint) = &config.public_endpoint {
+            let public_s3_config = Self::config_builder(&config, Some(public_endpoint.as_str()))
+                .await?
+                .region(Region::new(config.region.to_owned()))
+                .retry_config(RetryConfig::adaptive())
+                .build();
+
+            Some(Client::from_conf(public_s3_config))
+        } else {
+            None
+        };
+
         Ok(Self {
             client: Client::from_conf(s3_config),
+            public_download_client,
             config,
         })
     }
 
-    async fn config_builder(config: &S3StorageConfig) -> ServerResult<S3ConfigBuilder> {
+    async fn config_builder(
+        config: &S3StorageConfig,
+        endpoint_override: Option<&str>,
+    ) -> ServerResult<S3ConfigBuilder> {
         let shared_config = aws_config::load_defaults(BehaviorVersion::v2026_01_12()).await;
         let mut builder = S3ConfigBuilder::from(&shared_config);
 
@@ -105,7 +129,7 @@ impl S3Backend {
             ));
         }
 
-        if let Some(endpoint) = &config.endpoint {
+        if let Some(endpoint) = endpoint_override.or(config.endpoint.as_deref()) {
             builder = builder.endpoint_url(endpoint).force_path_style(true);
         }
 
@@ -115,6 +139,7 @@ impl S3Backend {
     async fn get_client_from_db_ref<'a>(
         &self,
         file: &'a RemoteFile,
+        for_presigned_url: bool,
     ) -> ServerResult<(Client, &'a S3RemoteFile)> {
         let file = if let RemoteFile::S3(file) = file {
             file
@@ -125,12 +150,24 @@ impl S3Backend {
             .into());
         };
 
+        let base_client = if for_presigned_url {
+            self.public_download_client.as_ref().unwrap_or(&self.client)
+        } else {
+            &self.client
+        };
+
         // FIXME: Ugly
-        let client = if self.client.config().region().unwrap().as_ref() == file.region {
-            self.client.clone()
+        let client = if base_client.config().region().unwrap().as_ref() == file.region {
+            base_client.clone()
         } else {
             // FIXME: Cache the client instance
-            let s3_conf = Self::config_builder(&self.config)
+            let endpoint_override = if for_presigned_url {
+                self.config.public_endpoint.as_deref()
+            } else {
+                None
+            };
+
+            let s3_conf = Self::config_builder(&self.config, endpoint_override)
                 .await?
                 .region(Region::new(file.region.to_owned()))
                 .build();
@@ -320,7 +357,7 @@ impl StorageBackend for S3Backend {
     }
 
     async fn delete_file_db(&self, file: &RemoteFile) -> ServerResult<()> {
-        let (client, file) = self.get_client_from_db_ref(file).await?;
+        let (client, file) = self.get_client_from_db_ref(file, false).await?;
 
         let deletion = client
             .delete_object()
@@ -340,7 +377,7 @@ impl StorageBackend for S3Backend {
         file: &RemoteFile,
         prefer_stream: bool,
     ) -> ServerResult<Download> {
-        let (client, file) = self.get_client_from_db_ref(file).await?;
+        let (client, file) = self.get_client_from_db_ref(file, !prefer_stream).await?;
 
         let req = client.get_object().bucket(&file.bucket).key(&file.key);
 


### PR DESCRIPTION
## Changes

- add optional `storage.public-endpoint` to S3 storage config
- keep internal S3 reads/writes/uploads/deletes on `storage.endpoint`
- use `storage.public-endpoint` only for generated presigned download URLs
- document the new setting in `server/src/config-template.toml`

## Validation
- cargo fmt --all -- --check
- cargo check -p attic-server
- cargo test -p attic-server
- cargo test --workspace
- functionality successfully tested against Garage S3 server
  - internally, direct unencrypted
  - publicly through SSL terminating reverse proxy 

Supersedes https://github.com/zhaofengli/attic/pull/289
Fixes https://github.com/zhaofengli/attic/issues/228
Closes https://github.com/zhaofengli/attic/issues/351