### PR TITLE
nix_store: bound the NAR channel so RSS stops scaling with path size

### DIFF
--- a/attic/src/nix_store/bindings/mod.rs
+++ b/attic/src/nix_store/bindings/mod.rs
@@ -43,10 +43,18 @@ pub unsafe fn open_nix_store() -> AtticResult<FfiNixStore> {
 // (tokio, crossbeam, flume)
 mod mpsc {
     // Tokio
-    pub use tokio::sync::mpsc::{
-        UnboundedReceiver, UnboundedSender, error::SendError, unbounded_channel,
-    };
+    pub use tokio::sync::mpsc::{Receiver, Sender, channel, error::SendError};
 }
+
+/// Number of buffered NAR blocks between the C++ serializer and the consumer.
+///
+/// The channel must be bounded: `nar_from_path` runs the synchronous C++
+/// serializer on a blocking thread, which produces data as fast as the store
+/// can be read, while the consumer (typically an HTTP upload) drains it at
+/// network speed. With an unbounded channel the difference accumulates in
+/// memory, so pushing a large store path grows RSS linearly with its size —
+/// a multi-gigabyte path is enough to get the client OOM-killed.
+const NAR_CHANNEL_CAPACITY: usize = 64;
 
 /// Async write request.
 #[derive(Debug)]
@@ -57,20 +65,26 @@ enum AsyncWriteMessage {
 }
 
 /// Async write request sender.
+///
+/// Every method here is called from the synchronous C++ serializer running on a
+/// blocking thread (see `NixStore::nar_from_path`), never from async context,
+/// so `blocking_send` is the correct way to wait for capacity: it applies
+/// backpressure to the serializer instead of letting the queue grow without
+/// bound.
 #[derive(Clone)]
 pub struct AsyncWriteSender {
-    sender: mpsc::UnboundedSender<AsyncWriteMessage>,
+    sender: mpsc::Sender<AsyncWriteMessage>,
 }
 
 impl AsyncWriteSender {
     fn send(&mut self, data: &[u8]) -> Result<(), mpsc::SendError<AsyncWriteMessage>> {
         let message = AsyncWriteMessage::Data(Vec::from(data));
-        self.sender.send(message)
+        self.sender.blocking_send(message)
     }
 
     fn eof(&mut self) -> Result<(), mpsc::SendError<AsyncWriteMessage>> {
         let message = AsyncWriteMessage::Eof;
-        self.sender.send(message)
+        self.sender.blocking_send(message)
     }
 
     pub(crate) fn rust_error(
@@ -78,19 +92,19 @@ impl AsyncWriteSender {
         error: impl std::error::Error,
     ) -> Result<(), impl std::error::Error> {
         let message = AsyncWriteMessage::Error(error.to_string());
-        self.sender.send(message)
+        self.sender.blocking_send(message)
     }
 }
 
 /// A wrapper of the `AsyncWrite` trait for the synchronous Nix C++ land.
 pub struct AsyncWriteAdapter {
-    receiver: mpsc::UnboundedReceiver<AsyncWriteMessage>,
+    receiver: mpsc::Receiver<AsyncWriteMessage>,
     eof: bool,
 }
 
 impl AsyncWriteAdapter {
     pub fn new() -> (Self, Box<AsyncWriteSender>) {
-        let (sender, receiver) = mpsc::unbounded_channel();
+        let (sender, receiver) = mpsc::channel(NAR_CHANNEL_CAPACITY);
 
         let r = Self {
             receiver,


### PR DESCRIPTION
## Problem

`attic push` gets OOM-killed on large store paths. We hit this pushing rendered
video: a single 5.54 GB `.mov` took the client past 3.8 GB RSS on an 8 GB
machine, and the kernel killed it mid-upload.

The cause is in `attic/src/nix_store/bindings/mod.rs`. `nar_from_path` runs the
synchronous C++ NAR serializer on a blocking thread and forwards each block
through `mpsc::unbounded_channel()`. `UnboundedSender::send` never blocks, so
the serializer produces at disk speed while the consumer — the HTTP upload —
drains at network speed, and the difference accumulates in the channel.

Peak RSS therefore grows linearly with the size of the path being pushed. That
also explains why it only shows up on large paths: a few hundred MB stays well
under any memory limit.

## Measurements

`attic push` of a single store path holding one incompressible file, peak RSS
of the client process (`VmRSS`, polled every 200 ms):

| payload | before | after |
|--------:|-------:|------:|
|  500 MB |  519 MB |  36 MB |
| 1000 MB |  977 MB |  36 MB |
| 2000 MB | 1921 MB |  36 MB |

Before the change RSS tracks the payload almost 1:1; after it is flat.

## The change

Use a bounded channel and `blocking_send`. Every send happens on the blocking
thread that drives the C++ serializer (`spawn_blocking` in
`NixStore::nar_from_path`), never in async context, so `blocking_send` is safe
and provides the backpressure that was missing: the serializer pauses once the
buffer is full instead of queueing without limit.

Capacity is 64 blocks. Memory is now bounded by the channel rather than the
payload.

## Notes

- The receiving side already uses `poll_recv`, which the bounded `Receiver`
  provides as well, so `AsyncWriteAdapter`'s `Stream` impl is unchanged.
- `AsyncWriteSender` stays `Clone`, which `store.rs` relies on for error
  reporting.
- The remaining unbounded channels (`client/src/push.rs`,
  `client/src/command/watch_store.rs`) carry path names rather than payload and
  are untouched here; the `watch_store` one is presumably what #233 and #54 are
  about.