### PR TITLE
server: store and serve ca-derivation realisations

### DIFF
--- a/attic/src/api/v1/mod.rs
+++ b/attic/src/api/v1/mod.rs
@@ -1,3 +1,4 @@
 pub mod cache_config;
 pub mod get_missing_paths;
 pub mod upload_path;
+pub mod upload_realisation;

--- a/attic/src/api/v1/upload_realisation.rs
+++ b/attic/src/api/v1/upload_realisation.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A realisation document, as Nix writes/reads it for a ca-derivation output.
+///
+/// This mirrors the on-disk `.doi` shape Nix produces (verified against
+/// Nix 2.34): `dependentRealisations` and `signatures` are round-tripped
+/// verbatim but not interpreted by Attic — CA outputs are
+/// self-authenticating, so an empty `signatures` array is normal and
+/// doesn't mean the realisation is untrusted.
+///
+/// `unknown fields` are intentionally allowed (no `deny_unknown_fields`)
+/// so a newer Nix that adds fields to this document doesn't fail to
+/// upload through an older Attic server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Realisation {
+    /// The resolved derivation output id, e.g. `sha256:<hex>!out`.
+    pub id: String,
+
+    /// The store path this output resolved to, as a **basename** (no
+    /// `/nix/store/` prefix).
+    #[serde(rename = "outPath")]
+    pub out_path: String,
+
+    /// Signatures over the realisation, as supplied by the client.
+    #[serde(default)]
+    pub signatures: Vec<String>,
+
+    /// Realisations of the derivation's dependencies that this output
+    /// depends on, keyed by their own derivation output id.
+    #[serde(default, rename = "dependentRealisations")]
+    pub dependent_realisations: HashMap<String, String>,
+}

--- a/attic/src/mime.rs
+++ b/attic/src/mime.rs
@@ -8,3 +8,6 @@ pub const NARINFO: &str = "text/x-nix-narinfo";
 
 /// .nar
 pub const NAR: &str = "application/x-nix-nar";
+
+/// .doi (realisation)
+pub const REALISATION: &str = "application/json";

--- a/server/src/api/binary_cache.rs
+++ b/server/src/api/binary_cache.rs
@@ -36,6 +36,16 @@ use attic::io::merge_chunks;
 use attic::mime;
 use attic::nix_store::StorePathHash;
 
+/// Matches a derivation output id, e.g. `sha256:<64 hex chars>!out`.
+///
+/// This is the same shape Nix uses for realisation ids (see
+/// api/v1/upload_realisation.rs for where it's produced/consumed). We only
+/// need to validate it well enough to reject obviously malformed requests
+/// before hitting the database.
+static DRV_OUTPUT_ID_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(r"^[a-z0-9]+:[0-9a-f]+![a-zA-Z0-9_+.-]+$").unwrap()
+});
+
 /// Nix cache information.
 ///
 /// An example of a correct response is as follows:
@@ -277,9 +287,80 @@ async fn get_nar(
     }
 }
 
+/// Gets a realisation for a resolved ca-derivation output.
+///
+/// - GET `/:cache/realisations/{drvOutputId}.doi`
+///
+/// This is how Nix discovers cached outputs of content-addressed
+/// derivations: the derivation output id alone doesn't determine the
+/// output path, so before substituting, Nix asks the cache for the
+/// realisation mapping it produced (see upstream nix-http-binary-cache-api-spec
+/// and attic issue #188). Without this route CA derivations could never be
+/// substituted from Attic even though the NAR itself was cached.
+#[instrument(skip_all, fields(cache_name, path))]
+#[axum_macros::debug_handler]
+async fn get_realisation(
+    Extension(state): Extension<State>,
+    Extension(req_state): Extension<RequestState>,
+    Path((cache_name, path)): Path<(CacheName, String)>,
+) -> ServerResult<Response> {
+    let drv_output_id = path
+        .strip_suffix(".doi")
+        .ok_or(ErrorKind::NotFound)?
+        .to_string();
+
+    if !DRV_OUTPUT_ID_RE.is_match(&drv_output_id) {
+        return Err(ErrorKind::NotFound.into());
+    }
+
+    tracing::debug!(
+        "Received request for realisation {} in {:?}",
+        drv_output_id,
+        cache_name
+    );
+
+    let database = state.database().await?;
+
+    // Same discovery/read gating as narinfo: public caches must be
+    // servable without authentication, and the "cache exists at all"
+    // signal must not leak to callers without discovery permission
+    // (find_realisation folds a missing cache and a missing realisation
+    // into the same NoSuchObject error for that reason).
+    let cache = database.find_cache(&cache_name).await?;
+
+    let permission = req_state
+        .auth
+        .get_permission_for_cache(&cache_name, cache.is_public);
+    permission.require_pull()?;
+
+    req_state.set_public_cache(cache.is_public);
+
+    let realisation = database
+        .find_realisation(&cache_name, &drv_output_id)
+        .await?;
+
+    Ok((
+        [(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static(mime::REALISATION),
+        )],
+        realisation.data,
+    )
+        .into_response())
+}
+
+// TODO(2.35): Nix 2.35 moves realisations under
+// `/{cache}/build-trace-v2/{drv}/{output}` (no `.doi` suffix; the id is
+// reassembled as `sha256:{drv}!{output}`). We didn't have a vendored copy
+// of the 2.35 protocol docs/headers to confirm the exact path shape and
+// content type offline, so this is left for a follow-up rather than guessed
+// at. The 2.34 `/realisations/{id}.doi` route above is unaffected either
+// way — Nix falls back to it for older caches.
+
 pub fn get_router() -> Router {
     Router::new()
         .route("/{cache}/nix-cache-info", get(get_nix_cache_info))
+        .route("/{cache}/realisations/{path}", get(get_realisation))
         .route("/{cache}/{path}", get(get_store_path_info))
         .route("/{cache}/nar/{path}", get(get_nar))
 }

--- a/server/src/api/v1/mod.rs
+++ b/server/src/api/v1/mod.rs
@@ -1,6 +1,7 @@
 mod cache_config;
 mod get_missing_paths;
 mod upload_path;
+mod upload_realisation;
 
 use axum::{
     Router,
@@ -14,6 +15,10 @@ pub(crate) fn get_router() -> Router {
             post(get_missing_paths::get_missing_paths),
         )
         .route("/_api/v1/upload-path", put(upload_path::upload_path))
+        .route(
+            "/_api/v1/upload-realisation/{cache}/{id}",
+            put(upload_realisation::upload_realisation),
+        )
         .route(
             "/{cache}/attic-cache-info",
             get(cache_config::get_cache_config),

--- a/server/src/api/v1/upload_realisation.rs
+++ b/server/src/api/v1/upload_realisation.rs
@@ -1,0 +1,111 @@
+//! Uploads a realisation for a resolved ca-derivation output.
+//!
+//! Realisations are how Nix substitutes content-addressed derivation
+//! outputs: before a CA output can be pulled from a cache, the cache must
+//! be able to answer "what store path did derivation output {id} resolve
+//! to." This endpoint is the write side of that (see api/binary_cache.rs
+//! for the read side, and attic issue #188 for why Attic didn't support
+//! this until now).
+
+use std::sync::LazyLock;
+
+use axum::body::Bytes;
+use axum::extract::{Extension, Path};
+use chrono::Utc;
+use regex::Regex;
+use sea_orm::ActiveValue::Set;
+use sea_orm::entity::prelude::*;
+use tracing::instrument;
+
+use crate::database::entity::realisation::{self, Entity as Realisation, InsertExt};
+use crate::error::{ErrorKind, ServerError, ServerResult};
+use crate::{RequestState, State};
+use attic::api::v1::upload_realisation::Realisation as RealisationDoc;
+use attic::cache::CacheName;
+
+/// Maximum accepted size of a `.doi` body.
+///
+/// Realisations are tiny JSON documents (an id, an output path basename,
+/// and some signatures); anything past this is not a realisation.
+const MAX_REALISATION_SIZE: usize = 64 * 1024;
+
+/// Matches a plausible Nix store path basename: a 32-character hash
+/// followed by `-` and a name, e.g. `<hash>-hello-2.12`.
+///
+/// This is only meant to catch obviously-wrong `outPath` values before we
+/// store them; it's not a full store path validator.
+static STORE_PATH_BASENAME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[0-9a-z]{32}-").unwrap());
+
+/// Uploads a realisation to a cache.
+///
+/// `PUT /_api/v1/upload-realisation/{cache}/{id}`
+///
+/// The body is the raw `.doi` JSON document. We store it verbatim (it's
+/// what gets served back byte-for-byte from the GET route), but validate
+/// enough of its shape first that a malformed upload fails loudly here
+/// rather than producing a realisation the substituter side can't make
+/// sense of later.
+#[instrument(skip_all, fields(cache_name, drv_output_id))]
+#[axum_macros::debug_handler]
+pub(crate) async fn upload_realisation(
+    Extension(state): Extension<State>,
+    Extension(req_state): Extension<RequestState>,
+    Path((cache_name, drv_output_id)): Path<(CacheName, String)>,
+    body: Bytes,
+) -> ServerResult<()> {
+    if body.len() > MAX_REALISATION_SIZE {
+        return Err(ErrorKind::RequestError(anyhow::anyhow!(
+            "Realisation document is too large"
+        ))
+        .into());
+    }
+
+    let database = state.database().await?;
+    let cache = req_state
+        .auth
+        .auth_cache(database, &cache_name, |cache, permission| {
+            permission.require_push()?;
+            Ok(cache)
+        })
+        .await?;
+
+    let doc: RealisationDoc =
+        serde_json::from_slice(&body).map_err(ServerError::request_error)?;
+
+    if doc.id != drv_output_id {
+        return Err(ErrorKind::RequestError(anyhow::anyhow!(
+            "Realisation id in body ({}) does not match the URL ({})",
+            doc.id,
+            drv_output_id
+        ))
+        .into());
+    }
+
+    if !STORE_PATH_BASENAME_RE.is_match(&doc.out_path) {
+        return Err(
+            ErrorKind::RequestError(anyhow::anyhow!("outPath is not a valid store path basename"))
+                .into(),
+        );
+    }
+
+    let username = req_state.auth.username().map(str::to_string);
+    let data = std::str::from_utf8(&body)
+        .map_err(ServerError::request_error)?
+        .to_string();
+
+    Realisation::insert(realisation::ActiveModel {
+        cache_id: Set(cache.id),
+        drv_output_id: Set(drv_output_id),
+        data: Set(data),
+        created_at: Set(Utc::now()),
+        created_by: Set(username),
+        ..Default::default()
+    })
+    .on_conflict_do_update()
+    .exec(database)
+    .await
+    .map_err(ServerError::database_error)?;
+
+    Ok(())
+}

--- a/server/src/database/entity/mod.rs
+++ b/server/src/database/entity/mod.rs
@@ -7,6 +7,7 @@ pub mod chunk;
 pub mod chunkref;
 pub mod nar;
 pub mod object;
+pub mod realisation;
 
 use sea_orm::entity::Value;
 use sea_orm::sea_query::{ArrayType, ColumnType, ValueType, ValueTypeErr, table::StringLen};

--- a/server/src/database/entity/realisation.rs
+++ b/server/src/database/entity/realisation.rs
@@ -1,0 +1,78 @@
+//! A realisation, mapping a resolved ca-derivation output to its store path.
+//!
+//! Nix's realisation mechanism is how content-addressed derivations get
+//! substituted: the derivation output id (e.g. `sha256:<hex>!out`) doesn't
+//! by itself say which store path it resolved to, so Nix asks the
+//! substituter for `/{cache}/realisations/{id}.doi` and gets back a small
+//! JSON document naming the output path (see api/binary_cache.rs and
+//! api/v1/upload_realisation.rs). We store that document verbatim and key
+//! it by cache + drv output id, mirroring how `object` rows are keyed by
+//! cache + store path hash.
+
+use sea_orm::entity::prelude::*;
+use sea_orm::sea_query::OnConflict;
+use sea_orm::Insert;
+
+pub type RealisationModel = Model;
+
+pub trait InsertExt {
+    fn on_conflict_do_update(self) -> Self;
+}
+
+/// A realisation in a binary cache.
+#[derive(Debug, Clone, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "realisation")]
+pub struct Model {
+    /// Unique numeric ID of the realisation.
+    #[sea_orm(primary_key)]
+    pub id: i64,
+
+    /// ID of the binary cache the realisation belongs to.
+    #[sea_orm(indexed)]
+    pub cache_id: i64,
+
+    /// The resolved derivation output id, e.g. `sha256:<hex>!out`.
+    pub drv_output_id: String,
+
+    /// The raw `.doi` JSON document, stored verbatim as received from the
+    /// client and served verbatim to substituting clients.
+    #[sea_orm(column_type = "Text")]
+    pub data: String,
+
+    /// Timestamp when the realisation is created.
+    pub created_at: ChronoDateTimeUtc,
+
+    /// The uploader of the realisation.
+    ///
+    /// This is a "username." Currently, it's set to the `sub` claim in
+    /// the client's JWT. Mirrors `object.created_by`.
+    pub created_by: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::cache::Entity",
+        from = "Column::CacheId",
+        to = "super::cache::Column::Id"
+    )]
+    Cache,
+}
+
+impl InsertExt for Insert<ActiveModel> {
+    fn on_conflict_do_update(self) -> Self {
+        self.on_conflict(
+            OnConflict::columns([Column::CacheId, Column::DrvOutputId])
+                .update_columns([Column::Data, Column::CreatedAt, Column::CreatedBy])
+                .to_owned(),
+        )
+    }
+}
+
+impl Related<super::cache::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Cache.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/server/src/database/migration/m20260904_000001_add_realisation_table.rs
+++ b/server/src/database/migration/m20260904_000001_add_realisation_table.rs
@@ -1,0 +1,69 @@
+use sea_orm_migration::prelude::*;
+
+use crate::database::entity::cache;
+use crate::database::entity::realisation::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260904_000001_add_realisation_table"
+    }
+}
+
+// Nix ca-derivations discover cached results through realisations: a mapping
+// from a resolved derivation output id (e.g. `sha256:<hex>!out`) to the
+// output path it produced. Substituters are queried at
+// `/{cache}/realisations/{id}.doi`. Attic didn't store or serve these
+// (upstream issue #188), so CA-derivation outputs could never be reused
+// through it. This table is the storage side of fixing that.
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Entity)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Column::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Column::CacheId).big_integer().not_null())
+                    .col(ColumnDef::new(Column::DrvOutputId).string().not_null())
+                    .col(ColumnDef::new(Column::Data).text().not_null())
+                    .col(
+                        ColumnDef::new(Column::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(Column::CreatedBy).string().null())
+                    .foreign_key(
+                        ForeignKeyCreateStatement::new()
+                            .name("fk_realisation_cache")
+                            .from_tbl(Entity)
+                            .from_col(Column::CacheId)
+                            .to_tbl(cache::Entity)
+                            .to_col(cache::Column::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-realisation-cache-drv-output")
+                    .table(Entity)
+                    .col(Column::CacheId)
+                    .col(Column::DrvOutputId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/server/src/database/migration/mod.rs
+++ b/server/src/database/migration/mod.rs
@@ -17,6 +17,7 @@ mod m20230112_000006_add_nar_completeness_hint;
 mod m20260508_000001_add_chunk_state_holders_index;
 mod m20260611_000001_add_nar_state_holders_index;
 mod m20260624_000001_remove_chunk_recovery;
+mod m20260904_000001_add_realisation_table;
 
 pub struct Migrator;
 
@@ -39,6 +40,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260508_000001_add_chunk_state_holders_index::Migration),
             Box::new(m20260611_000001_add_nar_state_holders_index::Migration),
             Box::new(m20260624_000001_remove_chunk_recovery::Migration),
+            Box::new(m20260904_000001_add_realisation_table::Migration),
         ]
     }
 }

--- a/server/src/database/mod.rs
+++ b/server/src/database/mod.rs
@@ -23,6 +23,7 @@ use entity::chunk::{self, ChunkModel, ChunkState, Entity as Chunk};
 use entity::chunkref;
 use entity::nar::{self, Entity as Nar, NarModel, NarState};
 use entity::object::{self, Entity as Object, ObjectModel};
+use entity::realisation::{self, Entity as Realisation, RealisationModel};
 
 // quintuple join time
 const SELECT_OBJECT: &str = "O_";
@@ -67,6 +68,17 @@ pub trait AtticDatabase: Send + Sync {
         &self,
         object_id: i64,
     ) -> impl Future<Output = ServerResult<()>> + Send;
+
+    /// Retrieves a realisation by cache and derivation output id.
+    ///
+    /// Returns `NoSuchObject` if absent, matching the narinfo 404 behavior,
+    /// since from the substituter's point of view a missing realisation is
+    /// just another kind of missing object.
+    fn find_realisation(
+        &self,
+        cache: &CacheName,
+        drv_output_id: &str,
+    ) -> impl Future<Output = ServerResult<RealisationModel>> + Send;
 }
 
 pub struct NarGuard {
@@ -324,6 +336,22 @@ impl AtticDatabase for DatabaseConnection {
         .map_err(ServerError::database_error)?;
 
         Ok(())
+    }
+
+    async fn find_realisation(
+        &self,
+        cache: &CacheName,
+        drv_output_id: &str,
+    ) -> ServerResult<RealisationModel> {
+        Realisation::find()
+            .join(JoinType::InnerJoin, realisation::Relation::Cache.def())
+            .filter(cache::Column::Name.eq(cache.as_str()))
+            .filter(cache::Column::DeletedAt.is_null())
+            .filter(realisation::Column::DrvOutputId.eq(drv_output_id))
+            .one(self)
+            .await
+            .map_err(ServerError::database_error)?
+            .ok_or_else(|| ErrorKind::NoSuchObject.into())
     }
 }
 


### PR DESCRIPTION
Closes the substitution gap described in #188 (details and reproduction in [my comment there](https://github.com/zhaofengli/attic/issues/188#issuecomment-5542162847)).

## Problem

Nix discovers cached outputs of content-addressed derivations through **realisations** — the mapping *resolved derivation output id → store path*, queried from substituters as `GET /{cache}/realisations/{id}.doi`. Attic stores and serves the NARs but answers 404 for realisations, so a CA output can never be substituted through it: the path is in the cache with nothing able to name it. For CA derivations with side effects, "rebuilds it all over again" means repeating the side effect — this bit us in production with S3 uploads being re-sent.

## Change

- New `realisation` table keyed by `(cache_id, drv_output_id)`, storing the `.doi` JSON document verbatim (migration modeled on the existing ones).
- `GET /{cache}/realisations/{id}.doi` in the binary cache API, with the same read/discovery gating as narinfo (public caches served unauthenticated, cache existence not leaked).
- `PUT /_api/v1/upload-realisation/{cache}/{id}`, requiring push permission; upsert semantics; body size capped; id and outPath validated. The document is round-tripped without interpretation — CA outputs are self-authenticating, so empty signature lists are normal.
- Shared `Realisation` type in the `attic` crate (unknown fields tolerated for forward compatibility).

No client changes required: Nix's stock `queryRealisation` does the reading, and writing can be done by a post-build hook (`nix realisation info "$DRV_PATH^*" --json` + HTTP PUT). A follow-up could teach `attic push` to upload realisations alongside paths.

Nix 2.35 moves the client lookup to `build-trace-v2/…`; serving that layout is left as a marked TODO rather than guessed at.

## Testing

- Toy CA derivation embedding `$(date)`: output pushed, realisation PUT, local output and realisation deleted → `nix build --extra-substituters http://…:8081/cache` fetches the `.doi` from this server and the NAR from another cache; output content (timestamp) unchanged, no rebuild.
- Migration + parity rehearsal against a copy of a production deployment: sqlite and Postgres 18; 12.8k existing objects untouched; narinfo responses byte-identical between the unpatched and patched server on the same database; PUT/GET roundtrip on the Postgres backend.

Diagnosed and implemented with the help of Claude Code.